### PR TITLE
fix: remove invalid 'devtools' from tauri.conf.json build section

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,8 +7,7 @@
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build",
     "devUrl": "http://localhost:1430",
-    "frontendDist": "../dist",
-    "devtools": true
+    "frontendDist": "../dist"
   },
   "app": {
     "withGlobalTauri": true,


### PR DESCRIPTION
## Root Cause

All build jobs (macOS, Windows, Linux) were failing with:



The `build.devtools: true` property is **not valid in Tauri 2.0**. In Tauri 2, devtools are enabled differently (via app-level configuration or Cargo features).

## Fix

Remove `devtools: true` from the `build` section in `src-tauri/tauri.conf.json`.