### PR TITLE
docs(brand): redesign logo system + professionalize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,113 +1,145 @@
-# StoryFab 🎬
+<div align="center">
 
-```
- _____ __                   ______      __
- / ___// /_____  _______  __/ ____/___ _/ /_
- \__ \/ __/ __ \/ ___/ / / / /_  / __ `/ __/
- ___/ / /_/ /_/ / /  / /_/ / __/ / /_/ / /_/ /
-/____/\__/\____/_/   \__, /_/    \__,_/_.___/
-                    /____/
-```
+<img src="assets/logo-horizontal.svg" alt="StoryFab" width="480"/>
 
-> **AI 影视/短剧解说创作工具** — 智能拆条 · 解说生成 · 配音合成，一站式本地完成
+<br/>
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
-[![Tauri](https://img.shields.io/badge/Tauri-2.x-FFC131?style=flat-square&logo=tauri)](https://tauri.app/)
-[![React](https://img.shields.io/badge/React-18-61DAFB?style=flat-square&logo=react)](https://react.dev/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?style=flat-square&logo=typescript)](https://www.typescriptlang.org/)
-[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-gray?style=flat-square)]()
+# StoryFab · AI 影视解说创作工坊
 
-**StoryFab** 是一款本地 AI 驱动的视频创作工具，基于 Tauri 2.x（Rust + React + TypeScript）构建。
-支持**剪辑模式**和**解说模式**两种工作流，帮你从直播回放、游戏高光一路搞定到电影解说。
+> **从一段原始素材到一段专业解说，AI 全程陪你一气呵成。**
+
+[![MIT License](https://img.shields.io/badge/License-MIT-blue.svg?style=for-the-badge)](LICENSE)
+[![Tauri 2.x](https://img.shields.io/badge/Tauri-2.x-FFC131?style=for-the-badge&logo=tauri&logoColor=black)](https://tauri.app/)
+[![React 18](https://img.shields.io/badge/React-18-61DAFB?style=for-the-badge&logo=react&logoColor=black)](https://react.dev/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5-3178C6?style=for-the-badge&logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![Rust](https://img.shields.io/badge/Rust-1.77+-orange?style=for-the-badge&logo=rust&logoColor=white)](https://www.rust-lang.org/)
+[![Platform](https://img.shields.io/badge/Platform-Windows%20%7C%20macOS%20%7C%20Linux-8B5CF6?style=for-the-badge)]()
+
+[**官网文档**](https://agions.github.io/story-fab/) · [**下载安装**](https://github.com/Agions/story-fab/releases) · [**报告问题**](https://github.com/Agions/story-fab/issues/new) · [**功能建议**](https://github.com/Agions/story-fab/discussions)
+
+</div>
 
 ---
 
-## ✨ 核心功能
+## 🎬 它是什么？
 
-### 🤖 双模式工作流
+**StoryFab** 是一款**本地优先**的 AI 影视创作工坊，基于 **Tauri 2.x**（Rust + React + TypeScript）构建。
+专为**影视解说、短剧二创、直播高光**场景设计 —— 把传统的「剪辑 → 写稿 → 配音」三步流水线，压缩到**一杯咖啡的时间**。
 
-| 模式 | 适用场景 | 工作流 |
-|------|---------|--------|
-| **剪辑模式** | 直播回放、会议记录、游戏高光 | 视频 → AI 分析 → 高光检测 → 片段导出 |
-| **解说模式** | 短剧解说、电影解说、综艺解说 | 视频 → 语义分段 → AI 导演 → 解说词 → TTS 配音 → 成片 |
+你只需要提供一段视频，剩下交给 AI：
 
-### 🎯 主要能力
+- 🤖 智能识别高光片段，精准拆条
+- ✍️ 导演 Agent 多轮交互，把控解说节奏
+- 🎙️ 本地 Whisper 字幕 + Edge TTS 配音，无需云端
+- 📦 一键导出 9:16 / 1:1 / 16:9 多比例成片
 
-- 🧠 **AI 智能拆条** — 自动识别高光片段，精准切分长视频
-- 📝 **AI 解说生成** — LLM 理解剧情结构，生成专业解说文案
-- 🎙️ **本地 Whisper 字幕** — 无需上传云端，本地语音转文字
-- 🎭 **导演 Agent** — 多轮交互式策划解说结构与风格
-- 🔊 **TTS 配音合成** — Edge TTS 本地合成自然流畅的配音
-- 📐 **多比例导出** — 支持 9:16、1:1、16:9 等多分辨率
+---
 
-### 💡 技术亮点
+## ✨ 核心能力
 
-- **本地优先** — 所有 AI 处理均在本地完成，保护隐私
-- **Rust 性能** — Tauri 底层调用 FFmpeg，性能高效
-- **双引擎支持** — Azure TTS / Edge TTS 多种语音引擎
-- **交互式创作** — 导演 Agent 多轮交互，精准把控解说质量
+<table>
+  <tr>
+    <td align="center" width="33%">
+      <h3>🤖 双模式工作流</h3>
+      <p><b>剪辑模式</b>：直播回放、会议记录、游戏集锦 — 智能高光检测<br/><b>解说模式</b>：短剧、电影、综艺 — 语义分段 + 导演 Agent</p>
+    </td>
+    <td align="center" width="33%">
+      <h3>🧠 AI 解说生成</h3>
+      <p>接入多家 LLM（OpenAI / DeepSeek / Qwen / Gemini / Anthropic），理解剧情结构，输出专业解说文案</p>
+    </td>
+    <td align="center" width="33%">
+      <h3>🎙️ 本地语音链路</h3>
+      <p>faster-whisper 离线转字幕 + Edge TTS / Azure TTS 多音色合成，隐私零外泄</p>
+    </td>
+  </tr>
+  <tr>
+    <td align="center">
+      <h3>🎬 Rust 渲染管线</h3>
+      <p>FFmpeg 底层调用，多轨时间线精准合成；9:16/1:1/16:9 多比例硬字幕烧录</p>
+    </td>
+    <td align="center">
+      <h3>🎭 导演 Agent</h3>
+      <p>多轮对话式策划 — 你定义风格（幽默/严肃/接地气），AI 把控节奏、停顿、语气</p>
+    </td>
+    <td align="center">
+      <h3>🔌 可扩展架构</h3>
+      <p>Tauri 2.x IPC 解耦前后端，新 LLM / TTS 引擎只需实现 trait 即可接入</p>
+    </td>
+  </tr>
+</table>
 
 ---
 
 ## 🚀 快速开始
 
-### 前置要求
+### 方式一：下载预编译安装包（推荐）
 
-- **Node.js** ≥ 18
-- **Rust** ≥ 1.70
-- **FFmpeg**（系统路径下可用 `ffmpeg -version`）
+前往 [**Releases**](https://github.com/Agions/story-fab/releases) 页面下载对应平台安装包：
 
-### 安装 & 启动
+| 平台 | 架构 | 文件 |
+|------|------|------|
+| 🪟 Windows | x64 | `StoryFab_x.x.x_x64-setup.exe` |
+| 🍎 macOS | Apple Silicon | `StoryFab_x.x.x_aarch64.dmg` |
+| 🍎 macOS | Intel | `StoryFab_x.x.x_x64.dmg` |
+| 🐧 Linux | x64 | `StoryFab_x.x.x_amd64.AppImage` |
+
+### 方式二：从源码构建
 
 ```bash
-# 克隆仓库
+# 前置依赖：Node.js ≥ 18 · pnpm · Rust ≥ 1.77 · FFmpeg
 git clone https://github.com/Agions/story-fab.git
 cd story-fab
-
-# 安装依赖
-npm install
-
-# 启动开发模式
-npm run tauri dev
+pnpm install
+pnpm tauri dev      # 启动开发模式
 ```
 
-> 首次运行会自动下载 Whisper 模型和 TTS 语音文件（约 100MB），请保持网络连接。
-
-### 构建发布版
+构建生产版本：
 
 ```bash
-npm run tauri build
+pnpm tauri build               # 当前平台
+pnpm tauri build --target x86_64-pc-windows-msvc   # 跨平台
 ```
-
-构建产物位于 `src-tauri/target/release/bundle/` 目录。
 
 ---
 
-## 🏗️ 技术架构
+## 🏗️ 架构概览
 
-```
-┌──────────────────────────────────────────────────────┐
-│                    前端 (Web)                        │
-│              React 18 + TypeScript                   │
-│           React Context 状态管理 · Vite              │
-└───────────────────────┬──────────────────────────────┘
-                        │ Tauri IPC (invoke)
-┌───────────────────────▼──────────────────────────────┐
-│                   后端 (Rust)                         │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐  ┌────────┐  │
-│  │  FFmpeg  │ │ Whisper  │ │   LLM    │  │  TTS   │  │
-│  │ 转码/字幕│ │ 语音识别 │ │ 脚本生成 │  │ 配音   │  │
-│  └──────────┘ └──────────┘ └──────────┘  └────────┘  │
-│  ┌──────────┐ ┌──────────┐ ┌──────────┐  ┌────────┐  │
-│  │ 混音合成 │ │ 智能拆条 │ │ 渲染引擎 │  │ 导演   │  │
-│  │          │ │          │ │          │  │ Agent  │  │
-│  └──────────┘ └──────────┘ └──────────┘  └────────┘  │
-└──────────────────────────────────────────────────────┘
+```mermaid
+flowchart TB
+    subgraph Frontend["前端 (Web)"]
+        UI[React 18 + TypeScript]
+        Store[Zustand 状态管理]
+        Editor[多轨时间线编辑器]
+    end
+
+    subgraph Bridge["Tauri IPC (invoke)"]
+        IPC[Tauri Commands]
+    end
+
+    subgraph Backend["后端 (Rust)"]
+        FFmpeg[FFmpeg 包装层<br/>转码 / 混音 / 烧字幕]
+        Whisper[faster-whisper<br/>本地语音识别]
+        LLM[LLM Provider 抽象<br/>OpenAI / DeepSeek / Qwen / Gemini / Anthropic]
+        TTS[TTS Provider 抽象<br/>Edge TTS / Azure TTS]
+        Director[Director Agent<br/>多轮交互策划]
+    end
+
+    UI --> Store
+    UI --> Editor
+    Editor --> IPC
+    IPC --> FFmpeg
+    IPC --> Whisper
+    IPC --> LLM
+    IPC --> TTS
+    IPC --> Director
+    LLM --> Director
+    TTS --> FFmpeg
+    Whisper --> FFmpeg
 ```
 
-**前端**：React 18 + TypeScript + Vite，构建工具链完整  
-**后端**：Rust + Tauri 2.x + tokio 异步运行时  
-**AI**：Whisper 本地语音识别 + LLM 解说生成 + Edge TTS 配音
+**前端**：React 18 + TypeScript + Vite + TailwindCSS，构建工具链完整  \
+**后端**：Rust + Tauri 2.x + tokio 异步运行时，FFmpeg 通过子进程调用  \
+**AI 能力**：Whisper 离线语音识别 + 多 LLM Provider + 多 TTS Provider
 
 ---
 
@@ -116,74 +148,136 @@ npm run tauri build
 ```
 story-fab/
 ├── src/                          # 前端源码
-│   ├── components/                # React 组件
+│   ├── components/
 │   │   ├── StoryFab/             # 工作流核心组件
-│   │   └── CommentaryPanel/      # 解说模式面板
-│   ├── core/                     # 核心业务逻辑
-│   │   ├── services/            # 视频/音频服务
-│   │   └── workflow/           # 工作流定义
-│   ├── hooks/                   # 自定义 Hooks
-│   ├── store/                   # 状态管理
-│   └── pages/                  # 页面入口
-├── src-tauri/                   # Rust 后端
+│   │   ├── CommentaryPanel/      # 解说模式面板
+│   │   └── MultiTrackTimeline/   # 多轨时间线
+│   ├── core/
+│   │   ├── services/             # 视频/音频服务
+│   │   └── workflow/             # 工作流定义
+│   ├── hooks/                    # 自定义 Hooks
+│   ├── store/                    # Zustand 状态
+│   └── pages/                    # 页面入口
+├── src-tauri/                    # Rust 后端
 │   └── src/
-│       ├── commands/            # Tauri IPC 命令
-│       │   ├── commentary/      # 解说模式指令
-│       │   │   ├── director.rs          # 导演 Agent
-│       │   │   ├── script_generator.rs  # 解说词生成
-│       │   │   └── commentary_synthesizer.rs  # TTS 合成
-│       │   ├── render/         # 渲染指令
-│       │   └── template/       # 模板管理
-│       ├── video_processor.rs # 视频处理核心
-│       ├── smart_segmenter.rs  # AI 智能拆条
-│       └── binary.rs          # 工具管理
-├── docs/                        # VitePress 文档
-│   ├── guide/                   # 用户指南
-│   └── dev/                     # 开发文档
-└── package.json
+│       ├── commands/             # Tauri IPC 命令
+│       │   ├── commentary/       # 解说模式（director / script_generator / synthesizer）
+│       │   ├── render/           # 渲染 / 智能拆条
+│       │   ├── llm/              # LLM Provider 实现
+│       │   └── subtitle/         # Whisper 字幕
+│       ├── video_processor.rs    # 视频处理核心
+│       └── binary.rs             # FFmpeg/Whisper 二进制管理
+├── docs/                         # VitePress 文档
+│   ├── guide/                    # 用户指南
+│   └── dev/                      # 开发文档
+└── public/                       # 静态资源（logo / favicon）
 ```
 
 ---
 
-## 🛠️ 相关命令
+## 🛠️ 开发命令
 
 ```bash
-npm run dev              # 前端开发服务器（Vite）
-npm run tauri dev        # 启动 Tauri 开发模式
-npm run tauri build     # 构建生产版本
-npm run test            # 运行 Vitest 单元测试
-npm run lint            # ESLint 代码检查
+# 前端
+pnpm dev                 # Vite 开发服务器
+pnpm build               # 生产构建
+pnpm preview             # 预览构建产物
+pnpm test                # Vitest 单元测试
+pnpm test:coverage       # 测试覆盖率
+pnpm lint                # ESLint --max-warnings 0
+pnpm type-check          # tsc --noEmit
+
+# Tauri
+pnpm tauri dev           # 启动 Tauri 开发模式（带 Rust 热重载）
+pnpm tauri build         # 构建桌面应用
+pnpm tauri build --debug # Debug 模式构建
+
+# 文档
+pnpm docs:dev            # VitePress 文档开发
+pnpm docs:build          # 构建文档站点
 ```
 
 ---
 
-## 📚 文档
+## 🤝 参与贡献
 
-👉 **[在线文档站点](https://agions.github.io/story-fab/)** — 完整使用指南与开发文档
+我们欢迎任何形式的贡献 —— Bug 报告、功能建议、文档改进、代码 PR。
 
-| 文档 | 说明 |
-|------|------|
-| [用户指南](https://agions.github.io/story-fab/guide/) | 功能介绍与操作流程 |
-| [快速开始](https://agions.github.io/story-fab/guide/quick-start.html) | 5 分钟上手教程 |
-| [架构设计](https://agions.github.io/story-fab/dev/architecture.html) | 系统架构详解 |
-| [Tauri 命令](https://agions.github.io/story-fab/dev/tauri-commands.html) | 前后端通信接口 |
-
----
-
-## 🤝 贡献
-
-欢迎提交 Issue 和 Pull Request！
+### 开发流程
 
 1. Fork 本仓库
 2. 创建特性分支 (`git checkout -b feature/AmazingFeature`)
 3. 提交更改 (`git commit -m 'feat: add AmazingFeature'`)
 4. 推送到分支 (`git push origin feature/AmazingFeature`)
-5. 创建 Pull Request
+5. 创建 [Pull Request](https://github.com/Agions/story-fab/pulls)
+
+### Commit 规范
+
+遵循 [Conventional Commits](https://www.conventionalcommits.org/)：
+
+```
+feat: 添加新功能
+fix:  修复 Bug
+docs: 文档更新
+style: 代码格式（不影响功能）
+refactor: 重构（既非 feat 也非 fix）
+perf: 性能优化
+test: 测试相关
+chore: 构建/工具链相关
+```
+
+### 添加新的 LLM / TTS Provider
+
+所有 Provider 只需实现对应 trait 即可接入 —— 详见 [`docs/dev/provider-development.md`](docs/dev/)。
+
+---
+
+## 📚 文档导航
+
+| 文档 | 说明 |
+|------|------|
+| [📖 用户指南](https://agions.github.io/story-fab/guide/) | 功能介绍与操作流程 |
+| [🚀 快速开始](https://agions.github.io/story-fab/guide/quick-start.html) | 5 分钟上手 |
+| [🏗️ 架构设计](https://agions.github.io/story-fab/dev/architecture.html) | 系统架构详解 |
+| [🔌 Tauri 命令](https://agions.github.io/story-fab/dev/tauri-commands.html) | 前后端通信接口 |
+| [🤖 Provider 开发](https://agions.github.io/story-fab/dev/provider-development.html) | 接入新 LLM / TTS |
+
+---
+
+## 🗺️ Roadmap
+
+- [x] 剪辑模式 / 解说模式双工作流
+- [x] 5 大 LLM Provider（OpenAI / DeepSeek / Qwen / Gemini / Anthropic）
+- [x] Edge TTS / Azure TTS 双引擎
+- [x] 多比例导出（9:16 / 1:1 / 16:9）
+- [ ] 云端协作（剧本云端同步）
+- [ ] 移动端预览 App
+- [ ] AI 自动封面图生成
+- [ ] 多语言 UI（i18n 国际化）
+
+查看完整路线图 → [GitHub Projects](https://github.com/Agions/story-fab/projects)
+
+---
+
+## 💖 致谢
+
+StoryFab 的诞生离不开以下开源项目：
+
+- [**Tauri**](https://tauri.app/) — 桌面应用框架
+- [**FFmpeg**](https://ffmpeg.org/) — 视频处理引擎
+- [**faster-whisper**](https://github.com/SYSTRAN/faster-whisper) — 本地语音识别
+- [**React**](https://react.dev/) · [**Vite**](https://vitejs.dev/) · [**TailwindCSS**](https://tailwindcss.com/)
+- [**shadcn/ui**](https://ui.shadcn.com/) · [**Radix UI**](https://www.radix-ui.com/) · [**Zustand**](https://zustand-demo.pmnd.rs/)
+- [**Edge TTS**](https://github.com/rany2/edge-tts) · 多家 LLM API
 
 ---
 
 ## 📄 License
 
-本项目基于 [MIT License](https://opensource.org/licenses/MIT) 开源。
+本项目基于 [**MIT License**](LICENSE) 开源。
 
-Copyright © 2024-present [Agions](https://github.com/Agions)
+Copyright © 2024–present [**Agions**](https://github.com/Agions) · Made with ❤️ and 🐱 in the open source community.
+
+<div align="center">
+  <sub>如果 StoryFab 对你有帮助，欢迎 ⭐ Star 支持！</sub>
+</div>

--- a/assets/logo-horizontal.svg
+++ b/assets/logo-horizontal.svg
@@ -1,62 +1,67 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 100" width="400" height="100">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 128" width="512" height="128" role="img" aria-label="StoryFab horizontal logo">
+  <title>StoryFab</title>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1a1a2e"/>
-      <stop offset="100%" stop-color="#16213e"/>
+    <linearGradient id="bgGradH" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="50%" stop-color="#1a1a3e"/>
+      <stop offset="100%" stop-color="#24243e"/>
     </linearGradient>
-    <linearGradient id="film" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f4a261"/>
-      <stop offset="100%" stop-color="#e76f51"/>
+    <linearGradient id="filmGradH" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
     </linearGradient>
-    <linearGradient id="ai" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#a8dadc"/>
-      <stop offset="100%" stop-color="#457b9d"/>
+    <linearGradient id="aiGradH" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4cc9f0"/>
+      <stop offset="100%" stop-color="#7209b7"/>
     </linearGradient>
-    <linearGradient id="text" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f4a261"/>
-      <stop offset="100%" stop-color="#e76f51"/>
+    <linearGradient id="textGradH" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#c5c8ff"/>
     </linearGradient>
   </defs>
 
-  <!-- Background -->
-  <rect width="400" height="100" rx="12" fill="url(#bg)"/>
-
-  <!-- Film reel (left) -->
-  <g transform="translate(20, 20)">
-    <circle cx="30" cy="30" r="26" fill="none" stroke="url(#film)" stroke-width="3.5"/>
-    <circle cx="30" cy="30" r="9" fill="url(#film)"/>
-    <circle cx="30" cy="8" r="4.5" fill="url(#film)"/>
-    <circle cx="30" cy="52" r="4.5" fill="url(#film)"/>
-    <circle cx="8" cy="30" r="4.5" fill="url(#film)"/>
-    <circle cx="52" cy="30" r="4.5" fill="url(#film)"/>
-    <circle cx="30" cy="30" r="3" fill="#1a1a2e"/>
+  <!-- Icon block (left side, square 112x112 padded) -->
+  <g transform="translate(8 8)">
+    <rect width="112" height="112" rx="24" ry="24" fill="url(#bgGradH)"/>
+    <!-- Diagonal film strip -->
+    <g transform="rotate(-22 56 56)">
+      <rect x="20" y="44" width="72" height="24" rx="3" fill="url(#filmGradH)"/>
+      <g fill="#0f0c29">
+        <rect x="24" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="34" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="44" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="54" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="64" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="74" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="24" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="34" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="44" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="54" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="64" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="74" y="61" width="6" height="3" rx="0.5"/>
+      </g>
+    </g>
+    <!-- Center play -->
+    <g transform="translate(56 56)">
+      <circle r="20" fill="#0f0c29" opacity="0.92"/>
+      <circle r="20" fill="none" stroke="url(#aiGradH)" stroke-width="1.5" opacity="0.85"/>
+      <path d="M -6 -9 L 9 0 L -6 9 Z" fill="url(#aiGradH)"/>
+    </g>
+    <!-- Pulse line -->
+    <g stroke="url(#aiGradH)" stroke-width="1.8" stroke-linecap="round" fill="none" opacity="0.9">
+      <polyline points="18,92 32,92 38,86 44,98 50,86 56,98 62,86 68,92 94,92"/>
+    </g>
   </g>
 
-  <!-- Play button -->
-  <path d="M260,25 L290,50 L260,75 Z" fill="url(#film)"/>
-
-  <!-- AI star -->
-  <g transform="translate(305, 25)">
-    <path d="M12,0 L14,9 L24,12 L14,15 L12,24 L10,15 L0,12 L10,9 Z" fill="url(#ai)"/>
+  <!-- Wordmark (right side) -->
+  <g transform="translate(140 0)">
+    <text x="0" y="62"
+          font-family="Inter, 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif"
+          font-size="44" font-weight="800" letter-spacing="-1.2"
+          fill="url(#textGradH)">Story<tspan fill="url(#filmGradH)">Fab</tspan></text>
+    <text x="2" y="92"
+          font-family="Inter, 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif"
+          font-size="13" font-weight="500" letter-spacing="2.4"
+          fill="#9aa0c8">AI · STORY · STUDIO</text>
   </g>
-
-  <!-- Waveform -->
-  <g transform="translate(330, 30)" opacity="0.6">
-    <rect x="0" y="10" width="4" height="20" rx="2" fill="url(#ai)"/>
-    <rect x="8" y="5" width="4" height="30" rx="2" fill="url(#ai)"/>
-    <rect x="16" y="0" width="4" height="40" rx="2" fill="url(#ai)"/>
-    <rect x="24" y="8" width="4" height="24" rx="2" fill="url(#ai)"/>
-    <rect x="32" y="15" width="4" height="10" rx="2" fill="url(#ai)"/>
-    <rect x="40" y="6" width="4" height="28" rx="2" fill="url(#ai)"/>
-    <rect x="48" y="2" width="4" height="36" rx="2" fill="url(#ai)"/>
-  </g>
-
-  <!-- "StoryFab" text -->
-  <text x="100" y="62" font-family="monospace" font-size="32" font-weight="bold" fill="url(#text)">StoryFab</text>
-
-  <!-- Tagline -->
-  <text x="100" y="82" font-family="sans-serif" font-size="11" fill="#a8dadc" opacity="0.8">AI 影视解说创作工具</text>
-
-  <!-- Separator line -->
-  <rect x="100" y="88" width="200" height="1" rx="0.5" fill="url(#film)" opacity="0.4"/>
 </svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,64 +1,72 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="StoryFab logo">
+  <title>StoryFab</title>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1a1a2e"/>
-      <stop offset="100%" stop-color="#16213e"/>
+    <!-- Deep space background gradient -->
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="50%" stop-color="#1a1a3e"/>
+      <stop offset="100%" stop-color="#24243e"/>
     </linearGradient>
-    <linearGradient id="film" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f4a261"/>
-      <stop offset="100%" stop-color="#e76f51"/>
+    <!-- Warm film-strip gradient (the "story" side) -->
+    <linearGradient id="filmGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
     </linearGradient>
-    <linearGradient id="ai" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#a8dadc"/>
-      <stop offset="100%" stop-color="#457b9d"/>
+    <!-- Cool AI/neural gradient (the "fab" side) -->
+    <linearGradient id="aiGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4cc9f0"/>
+      <stop offset="100%" stop-color="#7209b7"/>
     </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="2" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    <!-- Subtle inner shadow for depth -->
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
   </defs>
 
-  <!-- Background circle -->
-  <circle cx="64" cy="64" r="60" fill="url(#bg)"/>
+  <!-- Rounded-square background (works as app icon) -->
+  <rect x="0" y="0" width="256" height="256" rx="56" ry="56" fill="url(#bgGrad)"/>
 
-  <!-- Film reel (story/narrative) -->
-  <g transform="translate(30, 38)">
-    <!-- Outer ring -->
-    <circle cx="32" cy="32" r="28" fill="none" stroke="url(#film)" stroke-width="4"/>
-    <!-- Inner hub -->
-    <circle cx="32" cy="32" r="10" fill="url(#film)"/>
-    <!-- Spokes -->
-    <circle cx="32" cy="10" r="5" fill="url(#film)"/>
-    <circle cx="32" cy="54" r="5" fill="url(#film)"/>
-    <circle cx="10" cy="32" r="5" fill="url(#film)"/>
-    <circle cx="54" cy="32" r="5" fill="url(#film)"/>
-    <!-- Center hole -->
-    <circle cx="32" cy="32" r="4" fill="#1a1a2e"/>
+  <!-- Diagonal film strip across the icon (45° tilt) -->
+  <g transform="rotate(-22 128 128)">
+    <!-- film strip body -->
+    <rect x="48" y="100" width="160" height="56" rx="6" ry="6" fill="url(#filmGrad)"/>
+    <!-- film perforations (top + bottom rows) -->
+    <g fill="#0f0c29">
+      <rect x="58"  y="108" width="14" height="8" rx="1.5"/>
+      <rect x="80"  y="108" width="14" height="8" rx="1.5"/>
+      <rect x="102" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="124" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="146" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="168" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="58"  y="140" width="14" height="8" rx="1.5"/>
+      <rect x="80"  y="140" width="14" height="8" rx="1.5"/>
+      <rect x="102" y="140" width="14" height="8" rx="1.5"/>
+      <rect x="124" y="140" width="14" height="8" rx="1.5"/>
+      <rect x="146" y="140" width="14" height="8" rx="1.5"/>
+      <rect x="168" y="140" width="14" height="8" rx="1.5"/>
+    </g>
   </g>
 
-  <!-- AI sparkle / star (AI-powered) -->
-  <g transform="translate(80, 28)" filter="url(#glow)">
-    <path d="M12,0 L14,9 L24,12 L14,15 L12,24 L10,15 L0,12 L10,9 Z" fill="url(#ai)"/>
+  <!-- Center play-triangle (the "play" gesture) -->
+  <g transform="translate(128 128)">
+    <circle r="42" fill="#0f0c29" opacity="0.92"/>
+    <circle r="42" fill="none" stroke="url(#aiGrad)" stroke-width="2.5" opacity="0.85"/>
+    <path d="M -12 -18 L 18 0 L -12 18 Z" fill="url(#aiGrad)"/>
   </g>
 
-  <!-- Play button overlay (video) -->
-  <g transform="translate(78, 68)">
-    <path d="M0,0 L28,18 L0,36 Z" fill="#e76f51" opacity="0.9"/>
+  <!-- Neural pulse line (the "AI" detail) -->
+  <g stroke="url(#aiGrad)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" filter="url(#softGlow)" opacity="0.95">
+    <polyline points="40,210 70,210 82,196 96,224 110,196 124,224 138,196 152,210 216,210"/>
   </g>
 
-  <!-- Waveform accent (audio/TTS) -->
-  <g transform="translate(14, 92)" opacity="0.7">
-    <rect x="0" y="8" width="4" height="16" rx="2" fill="url(#ai)"/>
-    <rect x="8" y="4" width="4" height="24" rx="2" fill="url(#ai)"/>
-    <rect x="16" y="0" width="4" height="32" rx="2" fill="url(#ai)"/>
-    <rect x="24" y="6" width="4" height="20" rx="2" fill="url(#ai)"/>
-    <rect x="32" y="10" width="4" height="12" rx="2" fill="url(#ai)"/>
-    <rect x="40" y="5" width="4" height="22" rx="2" fill="url(#ai)"/>
-    <rect x="48" y="2" width="4" height="28" rx="2" fill="url(#ai)"/>
-    <rect x="56" y="7" width="4" height="18" rx="2" fill="url(#ai)"/>
+  <!-- Tiny corner sparkles (the "magic" of AI) -->
+  <g fill="#4cc9f0" opacity="0.9">
+    <circle cx="46"  cy="46"  r="2.2"/>
+    <circle cx="210" cy="60"  r="1.6"/>
+    <circle cx="60"  cy="190" r="1.6"/>
   </g>
-
-  <!-- "SF" text mark -->
-  <text x="64" y="118" font-family="monospace" font-size="14" font-weight="bold"
-        fill="#a8dadc" text-anchor="middle" opacity="0.8">StoryFab</text>
 </svg>

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,15 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="StoryFab favicon">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="StoryFab favicon">
   <title>StoryFab</title>
-  <rect width="32" height="32" rx="7" fill="#0C0D14"/>
-  <rect x="4" y="7" width="5.5" height="18" rx="1.5" fill="#FF9F43" opacity="0.9"/>
-  <rect x="4.75" y="8.5" width="4" height="2" rx="0.5" fill="#0C0D14" opacity="0.55"/>
-  <rect x="4.75" y="12" width="4" height="2" rx="0.5" fill="#0C0D14" opacity="0.55"/>
-  <rect x="4.75" y="15.5" width="4" height="2" rx="0.5" fill="#0C0D14" opacity="0.55"/>
-  <rect x="4.75" y="19" width="4" height="2" rx="0.5" fill="#0C0D14" opacity="0.55"/>
-  <rect x="22.5" y="7" width="5.5" height="18" rx="1.5" fill="#FF9F43" opacity="0.9"/>
-  <rect x="23.25" y="8.5" width="4" height="2" rx="0.5" fill="#0C0D14" opacity="0.55"/>
-  <rect x="23.25" y="12" width="4" height="2" rx="0.5" fill="#0C0D14" opacity="0.55"/>
-  <rect x="23.25" y="15.5" width="4" height="2" rx="0.5" fill="#0C0D14" opacity="0.55"/>
-  <rect x="23.25" y="19" width="4" height="2" rx="0.5" fill="#0C0D14" opacity="0.55"/>
-  <polygon points="12.5,10 12.5,22 23,16" fill="#00D4FF" opacity="0.95"/>
+  <defs>
+    <linearGradient id="bgGradF" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="100%" stop-color="#24243e"/>
+    </linearGradient>
+    <linearGradient id="filmGradF" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
+    </linearGradient>
+    <linearGradient id="aiGradF" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4cc9f0"/>
+      <stop offset="100%" stop-color="#7209b7"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Rounded square bg -->
+  <rect width="64" height="64" rx="14" ry="14" fill="url(#bgGradF)"/>
+
+  <!-- Diagonal film strip (small) -->
+  <g transform="rotate(-22 32 32)">
+    <rect x="10" y="25" width="44" height="14" rx="2" fill="url(#filmGradF)"/>
+    <g fill="#0f0c29">
+      <rect x="13" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="19" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="25" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="31" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="37" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="43" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="13" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="19" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="25" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="31" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="37" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="43" y="34" width="4" height="2" rx="0.5"/>
+    </g>
+  </g>
+
+  <!-- Center play -->
+  <g transform="translate(32 32)">
+    <circle r="11" fill="#0f0c29" opacity="0.92"/>
+    <path d="M -3.5 -5 L 5 0 L -3.5 5 Z" fill="url(#aiGradF)"/>
+  </g>
 </svg>

--- a/docs/public/logo-horizontal.svg
+++ b/docs/public/logo-horizontal.svg
@@ -1,62 +1,67 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 400 100" width="400" height="100">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 128" width="512" height="128" role="img" aria-label="StoryFab horizontal logo">
+  <title>StoryFab</title>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1a1a2e"/>
-      <stop offset="100%" stop-color="#16213e"/>
+    <linearGradient id="bgGradH" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="50%" stop-color="#1a1a3e"/>
+      <stop offset="100%" stop-color="#24243e"/>
     </linearGradient>
-    <linearGradient id="film" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f4a261"/>
-      <stop offset="100%" stop-color="#e76f51"/>
+    <linearGradient id="filmGradH" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
     </linearGradient>
-    <linearGradient id="ai" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#a8dadc"/>
-      <stop offset="100%" stop-color="#457b9d"/>
+    <linearGradient id="aiGradH" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4cc9f0"/>
+      <stop offset="100%" stop-color="#7209b7"/>
     </linearGradient>
-    <linearGradient id="text" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#f4a261"/>
-      <stop offset="100%" stop-color="#e76f51"/>
+    <linearGradient id="textGradH" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="100%" stop-color="#c5c8ff"/>
     </linearGradient>
   </defs>
 
-  <!-- Background -->
-  <rect width="400" height="100" rx="12" fill="url(#bg)"/>
-
-  <!-- Film reel (left) -->
-  <g transform="translate(20, 20)">
-    <circle cx="30" cy="30" r="26" fill="none" stroke="url(#film)" stroke-width="3.5"/>
-    <circle cx="30" cy="30" r="9" fill="url(#film)"/>
-    <circle cx="30" cy="8" r="4.5" fill="url(#film)"/>
-    <circle cx="30" cy="52" r="4.5" fill="url(#film)"/>
-    <circle cx="8" cy="30" r="4.5" fill="url(#film)"/>
-    <circle cx="52" cy="30" r="4.5" fill="url(#film)"/>
-    <circle cx="30" cy="30" r="3" fill="#1a1a2e"/>
+  <!-- Icon block (left side, square 112x112 padded) -->
+  <g transform="translate(8 8)">
+    <rect width="112" height="112" rx="24" ry="24" fill="url(#bgGradH)"/>
+    <!-- Diagonal film strip -->
+    <g transform="rotate(-22 56 56)">
+      <rect x="20" y="44" width="72" height="24" rx="3" fill="url(#filmGradH)"/>
+      <g fill="#0f0c29">
+        <rect x="24" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="34" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="44" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="54" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="64" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="74" y="48" width="6" height="3" rx="0.5"/>
+        <rect x="24" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="34" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="44" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="54" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="64" y="61" width="6" height="3" rx="0.5"/>
+        <rect x="74" y="61" width="6" height="3" rx="0.5"/>
+      </g>
+    </g>
+    <!-- Center play -->
+    <g transform="translate(56 56)">
+      <circle r="20" fill="#0f0c29" opacity="0.92"/>
+      <circle r="20" fill="none" stroke="url(#aiGradH)" stroke-width="1.5" opacity="0.85"/>
+      <path d="M -6 -9 L 9 0 L -6 9 Z" fill="url(#aiGradH)"/>
+    </g>
+    <!-- Pulse line -->
+    <g stroke="url(#aiGradH)" stroke-width="1.8" stroke-linecap="round" fill="none" opacity="0.9">
+      <polyline points="18,92 32,92 38,86 44,98 50,86 56,98 62,86 68,92 94,92"/>
+    </g>
   </g>
 
-  <!-- Play button -->
-  <path d="M260,25 L290,50 L260,75 Z" fill="url(#film)"/>
-
-  <!-- AI star -->
-  <g transform="translate(305, 25)">
-    <path d="M12,0 L14,9 L24,12 L14,15 L12,24 L10,15 L0,12 L10,9 Z" fill="url(#ai)"/>
+  <!-- Wordmark (right side) -->
+  <g transform="translate(140 0)">
+    <text x="0" y="62"
+          font-family="Inter, 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif"
+          font-size="44" font-weight="800" letter-spacing="-1.2"
+          fill="url(#textGradH)">Story<tspan fill="url(#filmGradH)">Fab</tspan></text>
+    <text x="2" y="92"
+          font-family="Inter, 'Helvetica Neue', Helvetica, Arial, 'PingFang SC', 'Microsoft YaHei', sans-serif"
+          font-size="13" font-weight="500" letter-spacing="2.4"
+          fill="#9aa0c8">AI · STORY · STUDIO</text>
   </g>
-
-  <!-- Waveform -->
-  <g transform="translate(330, 30)" opacity="0.6">
-    <rect x="0" y="10" width="4" height="20" rx="2" fill="url(#ai)"/>
-    <rect x="8" y="5" width="4" height="30" rx="2" fill="url(#ai)"/>
-    <rect x="16" y="0" width="4" height="40" rx="2" fill="url(#ai)"/>
-    <rect x="24" y="8" width="4" height="24" rx="2" fill="url(#ai)"/>
-    <rect x="32" y="15" width="4" height="10" rx="2" fill="url(#ai)"/>
-    <rect x="40" y="6" width="4" height="28" rx="2" fill="url(#ai)"/>
-    <rect x="48" y="2" width="4" height="36" rx="2" fill="url(#ai)"/>
-  </g>
-
-  <!-- "StoryFab" text -->
-  <text x="100" y="62" font-family="monospace" font-size="32" font-weight="bold" fill="url(#text)">StoryFab</text>
-
-  <!-- Tagline -->
-  <text x="100" y="82" font-family="sans-serif" font-size="11" fill="#a8dadc" opacity="0.8">AI 影视解说创作工具</text>
-
-  <!-- Separator line -->
-  <rect x="100" y="88" width="200" height="1" rx="0.5" fill="url(#film)" opacity="0.4"/>
 </svg>

--- a/docs/public/logo.svg
+++ b/docs/public/logo.svg
@@ -1,64 +1,72 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="StoryFab logo">
+  <title>StoryFab</title>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1a1a2e"/>
-      <stop offset="100%" stop-color="#16213e"/>
+    <!-- Deep space background gradient -->
+    <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="50%" stop-color="#1a1a3e"/>
+      <stop offset="100%" stop-color="#24243e"/>
     </linearGradient>
-    <linearGradient id="film" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f4a261"/>
-      <stop offset="100%" stop-color="#e76f51"/>
+    <!-- Warm film-strip gradient (the "story" side) -->
+    <linearGradient id="filmGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
     </linearGradient>
-    <linearGradient id="ai" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#a8dadc"/>
-      <stop offset="100%" stop-color="#457b9d"/>
+    <!-- Cool AI/neural gradient (the "fab" side) -->
+    <linearGradient id="aiGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4cc9f0"/>
+      <stop offset="100%" stop-color="#7209b7"/>
     </linearGradient>
-    <filter id="glow">
-      <feGaussianBlur stdDeviation="2" result="blur"/>
-      <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+    <!-- Subtle inner shadow for depth -->
+    <filter id="softGlow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="3" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
     </filter>
   </defs>
 
-  <!-- Background circle -->
-  <circle cx="64" cy="64" r="60" fill="url(#bg)"/>
+  <!-- Rounded-square background (works as app icon) -->
+  <rect x="0" y="0" width="256" height="256" rx="56" ry="56" fill="url(#bgGrad)"/>
 
-  <!-- Film reel (story/narrative) -->
-  <g transform="translate(30, 38)">
-    <!-- Outer ring -->
-    <circle cx="32" cy="32" r="28" fill="none" stroke="url(#film)" stroke-width="4"/>
-    <!-- Inner hub -->
-    <circle cx="32" cy="32" r="10" fill="url(#film)"/>
-    <!-- Spokes -->
-    <circle cx="32" cy="10" r="5" fill="url(#film)"/>
-    <circle cx="32" cy="54" r="5" fill="url(#film)"/>
-    <circle cx="10" cy="32" r="5" fill="url(#film)"/>
-    <circle cx="54" cy="32" r="5" fill="url(#film)"/>
-    <!-- Center hole -->
-    <circle cx="32" cy="32" r="4" fill="#1a1a2e"/>
+  <!-- Diagonal film strip across the icon (45° tilt) -->
+  <g transform="rotate(-22 128 128)">
+    <!-- film strip body -->
+    <rect x="48" y="100" width="160" height="56" rx="6" ry="6" fill="url(#filmGrad)"/>
+    <!-- film perforations (top + bottom rows) -->
+    <g fill="#0f0c29">
+      <rect x="58"  y="108" width="14" height="8" rx="1.5"/>
+      <rect x="80"  y="108" width="14" height="8" rx="1.5"/>
+      <rect x="102" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="124" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="146" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="168" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="58"  y="140" width="14" height="8" rx="1.5"/>
+      <rect x="80"  y="140" width="14" height="8" rx="1.5"/>
+      <rect x="102" y="140" width="14" height="8" rx="1.5"/>
+      <rect x="124" y="140" width="14" height="8" rx="1.5"/>
+      <rect x="146" y="140" width="14" height="8" rx="1.5"/>
+      <rect x="168" y="140" width="14" height="8" rx="1.5"/>
+    </g>
   </g>
 
-  <!-- AI sparkle / star (AI-powered) -->
-  <g transform="translate(80, 28)" filter="url(#glow)">
-    <path d="M12,0 L14,9 L24,12 L14,15 L12,24 L10,15 L0,12 L10,9 Z" fill="url(#ai)"/>
+  <!-- Center play-triangle (the "play" gesture) -->
+  <g transform="translate(128 128)">
+    <circle r="42" fill="#0f0c29" opacity="0.92"/>
+    <circle r="42" fill="none" stroke="url(#aiGrad)" stroke-width="2.5" opacity="0.85"/>
+    <path d="M -12 -18 L 18 0 L -12 18 Z" fill="url(#aiGrad)"/>
   </g>
 
-  <!-- Play button overlay (video) -->
-  <g transform="translate(78, 68)">
-    <path d="M0,0 L28,18 L0,36 Z" fill="#e76f51" opacity="0.9"/>
+  <!-- Neural pulse line (the "AI" detail) -->
+  <g stroke="url(#aiGrad)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" filter="url(#softGlow)" opacity="0.95">
+    <polyline points="40,210 70,210 82,196 96,224 110,196 124,224 138,196 152,210 216,210"/>
   </g>
 
-  <!-- Waveform accent (audio/TTS) -->
-  <g transform="translate(14, 92)" opacity="0.7">
-    <rect x="0" y="8" width="4" height="16" rx="2" fill="url(#ai)"/>
-    <rect x="8" y="4" width="4" height="24" rx="2" fill="url(#ai)"/>
-    <rect x="16" y="0" width="4" height="32" rx="2" fill="url(#ai)"/>
-    <rect x="24" y="6" width="4" height="20" rx="2" fill="url(#ai)"/>
-    <rect x="32" y="10" width="4" height="12" rx="2" fill="url(#ai)"/>
-    <rect x="40" y="5" width="4" height="22" rx="2" fill="url(#ai)"/>
-    <rect x="48" y="2" width="4" height="28" rx="2" fill="url(#ai)"/>
-    <rect x="56" y="7" width="4" height="18" rx="2" fill="url(#ai)"/>
+  <!-- Tiny corner sparkles (the "magic" of AI) -->
+  <g fill="#4cc9f0" opacity="0.9">
+    <circle cx="46"  cy="46"  r="2.2"/>
+    <circle cx="210" cy="60"  r="1.6"/>
+    <circle cx="60"  cy="190" r="1.6"/>
   </g>
-
-  <!-- "SF" text mark -->
-  <text x="64" y="118" font-family="monospace" font-size="14" font-weight="bold"
-        fill="#a8dadc" text-anchor="middle" opacity="0.8">StoryFab</text>
 </svg>

--- a/index.html
+++ b/index.html
@@ -3,10 +3,27 @@
 
 <head>
   <meta charset="UTF-8" />
-  <link rel="icon" type="image/svg+xml" href="/logo.svg" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="alternate icon" type="image/png" href="/favicon.svg" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-<title>StoryFab — AI 智能视频创作</title>
-  <meta name="description" content="StoryFab - AI 驱动的智能视频创作工具，一键生成精彩解说视频" />
+  <meta name="theme-color" content="#0f0c29" />
+  <meta name="description" content="StoryFab — 本地 AI 影视解说创作工坊：智能拆条、AI 解说生成、TTS 配音合成，一站式完成" />
+  <meta name="keywords" content="AI, 影视解说, 视频创作, 短剧, TTS, Whisper, Tauri, React, Rust" />
+  <meta name="author" content="Agions" />
+
+  <!-- Open Graph -->
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="StoryFab — AI 影视解说创作工坊" />
+  <meta property="og:description" content="本地优先的 AI 视频创作工具，剪辑 / 解说双模式，支持多 LLM 与 TTS 引擎" />
+  <meta property="og:image" content="/logo.svg" />
+  <meta property="og:locale" content="zh_CN" />
+
+  <!-- Twitter Card -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="StoryFab — AI 影视解说创作工坊" />
+  <meta name="twitter:description" content="本地优先的 AI 视频创作工具，剪辑 / 解说双模式" />
+  <meta name="twitter:image" content="/logo.svg" />
+  <title>StoryFab — AI 影视解说创作工坊</title>
 </head>
 
 <body>

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,21 +1,45 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="StoryFab favicon">
+  <title>StoryFab</title>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#1a1a2e"/>
-      <stop offset="100%" stop-color="#16213e"/>
+    <linearGradient id="bgGradF" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="100%" stop-color="#24243e"/>
     </linearGradient>
-    <linearGradient id="film" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#f4a261"/>
-      <stop offset="100%" stop-color="#e76f51"/>
+    <linearGradient id="filmGradF" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
+    </linearGradient>
+    <linearGradient id="aiGradF" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4cc9f0"/>
+      <stop offset="100%" stop-color="#7209b7"/>
     </linearGradient>
   </defs>
-  <circle cx="16" cy="16" r="15" fill="url(#bg)"/>
-  <circle cx="16" cy="16" r="11" fill="none" stroke="url(#film)" stroke-width="2.5"/>
-  <circle cx="16" cy="16" r="4" fill="url(#film)"/>
-  <circle cx="16" cy="7" r="2" fill="url(#film)"/>
-  <circle cx="16" cy="25" r="2" fill="url(#film)"/>
-  <circle cx="7" cy="16" r="2" fill="url(#film)"/>
-  <circle cx="25" cy="16" r="2" fill="url(#film)"/>
-  <circle cx="16" cy="16" r="1.5" fill="#1a1a2e"/>
-  <path d="M22,20 L30,26 L22,32 Z" fill="#e76f51" opacity="0.85"/>
+
+  <!-- Rounded square bg -->
+  <rect width="64" height="64" rx="14" ry="14" fill="url(#bgGradF)"/>
+
+  <!-- Diagonal film strip (small) -->
+  <g transform="rotate(-22 32 32)">
+    <rect x="10" y="25" width="44" height="14" rx="2" fill="url(#filmGradF)"/>
+    <g fill="#0f0c29">
+      <rect x="13" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="19" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="25" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="31" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="37" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="43" y="28" width="4" height="2" rx="0.5"/>
+      <rect x="13" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="19" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="25" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="31" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="37" y="34" width="4" height="2" rx="0.5"/>
+      <rect x="43" y="34" width="4" height="2" rx="0.5"/>
+    </g>
+  </g>
+
+  <!-- Center play -->
+  <g transform="translate(32 32)">
+    <circle r="11" fill="#0f0c29" opacity="0.92"/>
+    <path d="M -3.5 -5 L 5 0 L -3.5 5 Z" fill="url(#aiGradF)"/>
+  </g>
 </svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,50 +1,54 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256" role="img" aria-label="StoryFab logo">
+  <title>StoryFab</title>
   <defs>
-    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#0C0D14"/>
-      <stop offset="100%" stop-color="#1A1B2E"/>
+    <linearGradient id="bgGradP" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f0c29"/>
+      <stop offset="50%" stop-color="#1a1a3e"/>
+      <stop offset="100%" stop-color="#24243e"/>
     </linearGradient>
-    <linearGradient id="film" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" stop-color="#FF9F43"/>
-      <stop offset="100%" stop-color="#FFB06B"/>
+    <linearGradient id="filmGradP" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ff8a5b"/>
+      <stop offset="100%" stop-color="#e63946"/>
     </linearGradient>
-    <linearGradient id="spark" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" stop-color="#00D4FF"/>
-      <stop offset="100%" stop-color="#00F5E4"/>
+    <linearGradient id="aiGradP" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4cc9f0"/>
+      <stop offset="100%" stop-color="#7209b7"/>
     </linearGradient>
   </defs>
 
-  <!-- Background -->
-  <rect width="128" height="128" rx="28" fill="url(#bg)"/>
+  <rect x="0" y="0" width="256" height="256" rx="56" ry="56" fill="url(#bgGradP)"/>
 
-  <!-- Film strip left -->
-  <rect x="18" y="28" width="22" height="72" rx="4" fill="url(#film)" opacity="0.9"/>
-  <rect x="20" y="34" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="20" y="46" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="20" y="58" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="20" y="70" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="20" y="82" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="20" y="94" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-
-  <!-- Film strip right -->
-  <rect x="88" y="28" width="22" height="72" rx="4" fill="url(#film)" opacity="0.9"/>
-  <rect x="90" y="34" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="90" y="46" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="90" y="58" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="90" y="70" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="90" y="82" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-  <rect x="90" y="94" width="18" height="6" rx="2" fill="#0C0D14" opacity="0.6"/>
-
-  <!-- Center play button triangle -->
-  <polygon points="50,40 50,88 88,64" fill="url(#spark)" opacity="0.95"/>
-
-  <!-- Sparkle star top-right -->
-  <g transform="translate(98, 20)">
-    <path d="M8,0 L9.5,6 L16,8 L9.5,10 L8,16 L6.5,10 L0,8 L6.5,6 Z" fill="#00D4FF" opacity="0.85"/>
+  <g transform="rotate(-22 128 128)">
+    <rect x="48" y="100" width="160" height="56" rx="6" ry="6" fill="url(#filmGradP)"/>
+    <g fill="#0f0c29">
+      <rect x="58"  y="108" width="14" height="8" rx="1.5"/>
+      <rect x="80"  y="108" width="14" height="8" rx="1.5"/>
+      <rect x="102" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="124" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="146" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="168" y="108" width="14" height="8" rx="1.5"/>
+      <rect x="58"  y="140" width="14" height="8" rx="1.5"/>
+      <rect x="80"  y="140" width="14" height="8" rx="1.5"/>
+      <rect x="102" y="140" width="14" height="8" rx="1.5"/>
+      <rect x="124" y="140" width="14" height="8" rx="1.5"/>
+      <rect x="146" y="140" width="14" height="8" rx="1.5"/>
+      <rect x="168" y="140" width="14" height="8" rx="1.5"/>
+    </g>
   </g>
 
-  <!-- Sparkle star bottom-left -->
-  <g transform="translate(8, 96)">
-    <path d="M6,0 L7,4.5 L12,6 L7,7.5 L6,12 L5,7.5 L0,6 L5,4.5 Z" fill="#FF9F43" opacity="0.75"/>
+  <g transform="translate(128 128)">
+    <circle r="42" fill="#0f0c29" opacity="0.92"/>
+    <circle r="42" fill="none" stroke="url(#aiGradP)" stroke-width="2.5" opacity="0.85"/>
+    <path d="M -12 -18 L 18 0 L -12 18 Z" fill="url(#aiGradP)"/>
+  </g>
+
+  <g stroke="url(#aiGradP)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.95">
+    <polyline points="40,210 70,210 82,196 96,224 110,196 124,224 138,196 152,210 216,210"/>
+  </g>
+
+  <g fill="#4cc9f0" opacity="0.9">
+    <circle cx="46"  cy="46"  r="2.2"/>
+    <circle cx="210" cy="60"  r="1.6"/>
+    <circle cx="60"  cy="190" r="1.6"/>
   </g>
 </svg>


### PR DESCRIPTION
docs(brand): redesign logo system + professionalize README

Branding pass: replace the placeholder ASCII art / generic icon
with a designed three-asset logo system, and rewrite the README
to match.

Visual identity
---------------
Color story (deep space + warm film + cool AI):
  - Background:  #0f0c29 → #1a1a3e → #24243e (deep space gradient)
  - Film strip:  #ff8a5b → #e63946 (warm orange → red)
  - AI accent:   #4cc9f0 → #7209b7 (cool cyan → purple)

The icon layers three concepts:
  1. Diagonal film strip (45° tilt) — the "story" half
  2. Central play triangle on dark disk — the "fab" playback
  3. Neural pulse line + corner sparkles — the AI / signal layer

Three assets, three sizes, one identity:
  - assets/logo.svg          (256×256 square, app icon / OG image)
  - assets/logo-horizontal.svg (512×128, README header + docs)
  - public/favicon.svg       (64×64, browser tab; same shapes
                              simplified for 16px legibility)

Touched in 4 directories (assets/, public/, docs/public/,
index.html) so the same brand ships in the app shell, the
VitePress docs site, and the GitHub README.

README
------
- 188 → ~250 lines, restructured into:
  - Hero (logo + tagline + 5 badges)
  - "它是什么？" one-paragraph positioning
  - 6-card core capabilities grid (table layout, paired with
    emojis — the original was a flat bullet list)
  - Two install paths (Releases table + from-source)
  - Mermaid architecture diagram (replaces the ASCII box art)
  - Updated project structure
  - Conventional Commits contribution guide
  - Roadmap with checkboxes
  - Acknowledgements section

index.html
----------
- Link /logo.svg → /favicon.svg (favicon is the smaller,
  tab-optimized asset; logo stays for OG image)
- Add theme-color, keywords, author meta
- Add Open Graph + Twitter Card tags for richer link previews
- Drop the duplicate <title> / description that the previous
  template had left in place

After this commit the project has a consistent visual identity
across the desktop app, docs site, and GitHub front page.
