### PR TITLE
fix(batch-1): 修复 6 个隐藏 bug — Tauri listen 竞态 / 动态 import 竞态 / undefined spread / retry 边界 / 定时器泄露

### DIFF
--- a/src/components/StoryFab/workspace/VideoExport/useExportHandlers.ts
+++ b/src/components/StoryFab/workspace/VideoExport/useExportHandlers.ts
@@ -74,6 +74,7 @@ export function useExportHandlers({
   // 监听 Rust processing-progress 事件
   useEffect(() => {
     let unlisten: UnlistenFn | null = null;
+    let cancelled = false;
     if (exporting) {
       listen<{ stage: string; progress: number; time_remaining_secs?: number }>(
         'processing-progress',
@@ -85,9 +86,21 @@ export function useExportHandlers({
             setEtaSeconds(Math.round(time_remaining_secs));
           }
         }
-      ).then((fn) => { unlisten = fn; });
+      ).then((fn) => {
+        // If cleanup already ran before listen() resolved, unlisten immediately
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      }).catch((err) => {
+        console.error('[useExportHandlers] Failed to subscribe to processing-progress:', err);
+      });
     }
-    return () => { unlisten?.(); };
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
   }, [exporting]);
 
   const handleCancel = useCallback(async () => {

--- a/src/components/StoryFab/workspace/VideoUpload.tsx
+++ b/src/components/StoryFab/workspace/VideoUpload.tsx
@@ -113,9 +113,22 @@ const VideoUpload: React.FC<VideoUploadProps> = memo(({ onNext }) => {
 
       for (let i = 0; i < totalChunks; i++) {
         if (uploadStatusRef.current === 'paused') {
-          await new Promise<void>((resolve) => {
+          await new Promise<void>((resolve, reject) => {
+            // Track whether the interval is still active so we can clear it on cancel/error
+            let active = true;
             const checkResume = setInterval(() => {
+              if (!active) return;
+              if (uploadStatusRef.current === 'cancelled' || uploadStatusRef.current === 'error') {
+                active = false;
+                clearInterval(checkResume);
+                if (pauseIntervalRef.current === checkResume) {
+                  pauseIntervalRef.current = null;
+                }
+                reject(new Error('Upload cancelled or errored while paused'));
+                return;
+              }
               if (uploadStatusRef.current === 'uploading') {
+                active = false;
                 clearInterval(checkResume);
                 if (pauseIntervalRef.current === checkResume) {
                   pauseIntervalRef.current = null;

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -86,12 +86,20 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   // Subscribe to notify events
   useEffect(() => {
     let cleanup: (() => void) | undefined;
+    let cancelled = false;
     import('../../shared/utils/notify').then(({ subscribeToToast }) => {
+      // If cleanup already ran before import resolved, don't subscribe
+      if (cancelled) return;
       cleanup = subscribeToToast((event) => {
         addToast(event);
       });
+    }).catch((err) => {
+      console.error('[Toast] Failed to load notify module:', err);
     });
-    return () => cleanup?.();
+    return () => {
+      cancelled = true;
+      cleanup?.();
+    };
   }, [addToast]);
 
   const ctx: ToastContextValue = {

--- a/src/hooks/useCommentaryScript.ts
+++ b/src/hooks/useCommentaryScript.ts
@@ -183,11 +183,13 @@ export function useCommentaryScript(): UseCommentaryScriptResult {
   const updateSegment = useCallback((index: number, text: string) => {
     // Multi-style mode: update corresponding style's script
     if (multiStyleMode && activeScriptStyle) {
+      // Capture activeScriptStyle into a const so TS knows it's defined in closures
+      const styleKey = activeScriptStyle;
       setScripts((prev) => {
         const next = new Map(prev);
-        const current = next.get(activeScriptStyle!);
+        const current = next.get(styleKey);
         if (current) {
-          next.set(activeScriptStyle!, {
+          next.set(styleKey, {
             ...current,
             segments: current.segments.map((seg, i) =>
               i === index ? { ...seg, text } : seg

--- a/src/pages/ProjectDetail/index.tsx
+++ b/src/pages/ProjectDetail/index.tsx
@@ -110,7 +110,11 @@ const ProjectDetail: React.FC = () => {
 
   const schedulePersistUpdatedProject = useCallback((updatedProject: ProjectData, delayMs = 280) => {
     if (scriptPersistTimerRef.current) window.clearTimeout(scriptPersistTimerRef.current);
-    scriptPersistTimerRef.current = window.setTimeout(() => { void persistUpdatedProject(updatedProject); }, delayMs);
+    scriptPersistTimerRef.current = window.setTimeout(() => {
+      // Guard against firing after unmount
+      if (!mountedRef.current) return;
+      void persistUpdatedProject(updatedProject);
+    }, delayMs);
   }, []);
 
   useEffect(() => {

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -47,7 +47,11 @@ export async function retry<T>(
   attempts: number = 3,
   delayMs: number = 1000
 ): Promise<T> {
-  let lastError: Error;
+  if (attempts < 1) {
+    throw new Error('retry: attempts must be >= 1');
+  }
+
+  let lastError: Error | undefined;
 
   for (let i = 0; i < attempts; i++) {
     try {
@@ -60,7 +64,8 @@ export async function retry<T>(
     }
   }
 
-  throw lastError!;
+  // lastError is guaranteed to be set when attempts >= 1, but TS doesn't know
+  throw lastError ?? new Error('retry: failed without capturing an error');
 }
 
 /**


### PR DESCRIPTION
## 修复 6 个隐藏 bug (batch-1)

### 问题分类

#### 🟠 Tauri 事件监听竞态 (×2)
```
src/components/StoryFab/workspace/VideoExport/useExportHandlers.ts
src/components/ui/toast.tsx
```
`listen()` 和动态 `import()` 返回 Promise，unmount 时 cleanup 早于 resolve
→ 订阅句柄丢失，事件监听器和 notify 订阅泄漏
→ 修复：加 `cancelled` flag，cleanup 标记后 resolve 时立即解订/忽略

#### 🟠 Retry 边界 case (×1)
```
src/shared/utils/index.ts
```
`retry()` 当 `attempts=0` 时循环不执行，`lastError` 未定义
→ `throw lastError!` 实际抛 `undefined`
→ 修复：attempts<1 边界检查 + ?? new Error() fallback

#### 🟠 多样式脚本 undefined 崩溃 (×1)
```
src/hooks/useCommentaryScript.ts
```
`activeScriptStyle!` 在闭包里多次断言，TS 推断失效
→ 修复：提取 `styleKey` const 收紧作用域

#### 🟠 定时器/间隔泄露 (×2)
```
src/components/StoryFab/workspace/VideoUpload.tsx
src/pages/ProjectDetail/index.tsx
```
- 上传暂停时 setInterval 仅在 status='uploading' 清，cancel/error 状态泄漏
- setTimeout 回调未检查 mountedRef，组件卸载后仍触发 persist
→ 修复：Upload 加 cancelled/error 状态 reject；Detail 加 mountedRef guard

### 验证

```bash
npx tsc --noEmit  # ✅ 0 errors
npm run lint      # ✅ 0 errors (2 console warnings — acceptable)
```

### Diff
```
6 files changed, 54 insertions(+), 9 deletions(-)
```