### PR TITLE
ci(workflows): extract setup-pnpm composite action to dedup 6 jobs

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,26 @@
+name: Setup pnpm
+description: Setup Node.js + pnpm cache + pnpm install (must be combined with actions/checkout in calling job)
+runs:
+  using: composite
+  steps:
+    - name: Setup Node.js
+      uses: actions/setup-node@v5
+      with:
+        node-version: '22'
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v5
+      with:
+        path: ~/.pnpm-store
+        key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-
+
+    - name: Install pnpm
+      uses: pnpm/action-setup@v5
+      with:
+        version: '9'
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,31 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-      - name: Setup pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: '9'
-      - name: Install dependencies
-        run: pnpm install
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
       - name: TypeScript check
         run: |
           mkdir -p reports
-          # Run tsc, preserve all output, but ignore its exit code
           tsc --noEmit --pretty false > reports/tsc-report.txt 2>&1 || true
-          # Keep only src/ errors in the report for quality gate
           grep "^src/" reports/tsc-report.txt > reports/tsc-report-src.txt || true
-          # Fail only if there are src/ errors
           if grep -q "^src/" reports/tsc-report-src.txt; then
             echo "TypeScript errors found in src/"
             cat reports/tsc-report-src.txt
@@ -61,23 +43,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-      - name: Setup pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: '9'
-      - name: Install dependencies
-        run: pnpm install
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
       - name: Create reports directory
         run: mkdir -p reports
       - name: ESLint
@@ -98,23 +65,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-      - name: Setup pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: '9'
-      - name: Install dependencies
-        run: pnpm install
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
       - name: Create reports directory
         run: mkdir -p reports
       - name: Coverage with JSON reporter
@@ -198,23 +150,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-      - name: Setup pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: '9'
-      - name: Install dependencies
-        run: pnpm install
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
       - name: Build
         run: pnpm run build
       - name: Bundle budget check
@@ -236,16 +173,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
       - name: Setup pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: '9'
-      - name: Install frontend dependencies
-        run: pnpm install
+        uses: ./.github/actions/setup-pnpm
       - name: Build frontend
         run: pnpm run build
       - name: Install Rust toolchain
@@ -278,23 +207,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: '22'
-      - name: Setup pnpm cache
-        uses: actions/cache@v5
-        with:
-          path: ~/.pnpm-store
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-      - name: Install pnpm
-        uses: pnpm/action-setup@v5
-        with:
-          version: '9'
-      - name: Install dependencies
-        run: pnpm install
+      - name: Setup pnpm
+        uses: ./.github/actions/setup-pnpm
       - name: Download all reports
         uses: actions/download-artifact@v5
         with:


### PR DESCRIPTION
## 改动
- 提取 main.yml 重复的 4 步骤 (setup-node + pnpm cache + pnpm install + pnpm install) 为 `.github/actions/setup-pnpm` composite action
- 5 个 JS job (typecheck/lint/coverage/build/reports) 替换为一行 `uses: ./.github/actions/setup-pnpm`
- rust job 同样受益（重复步骤被替换）

## 影响
- main.yml: 319 → 232 行 (-87 行 / -27%)
- composite action: 25 行 (单点维护)
- 行为不变 (cache key / node version / pnpm version 全保留)

## 不在范围内
- Rust Check 当前 fail (tauri-utils 2.9.2 + time crate E0119 冲突) 是依赖版本问题，与本 PR 无关
- 计划在独立 `fix/rust-check` 分支处理