### PR TITLE
refactor(store): extract track history to createHistory module

### DIFF
--- a/src/store/createHistory.test.ts
+++ b/src/store/createHistory.test.ts
@@ -1,0 +1,89 @@
+/**
+ * createHistory 模块单元测试
+ *
+ * 验证 undo/redo 行为正确性、滑动窗口边界、未来栈清空规则
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createHistory } from './createHistory';
+
+type Snapshot = { value: number };
+
+describe('createHistory', () => {
+  let hist: ReturnType<typeof createHistory<Snapshot>>;
+
+  beforeEach(() => {
+    hist = createHistory<Snapshot>({ maxSize: 3 });
+  });
+
+  it('initial state: past and future are empty', () => {
+    expect(hist.size()).toEqual({ past: 0, future: 0 });
+    expect(hist.canUndo()).toBe(false);
+    expect(hist.canRedo()).toBe(false);
+  });
+
+  it('save pushes to past and clears future', () => {
+    hist.save({ value: 1 });
+    hist.save({ value: 2 });
+    expect(hist.size()).toEqual({ past: 2, future: 0 });
+    expect(hist.canUndo()).toBe(true);
+  });
+
+  it('undo pops from past, pushes current to future, returns previous', () => {
+    hist.save({ value: 1 });
+    hist.save({ value: 2 });
+    const current = { value: 3 };
+    const prev = hist.undo(current);
+    expect(prev).toEqual({ value: 2 });
+    expect(hist.size()).toEqual({ past: 1, future: 1 });
+    expect(hist.canRedo()).toBe(true);
+  });
+
+  it('undo returns undefined when past is empty', () => {
+    expect(hist.undo({ value: 0 })).toBeUndefined();
+    expect(hist.size()).toEqual({ past: 0, future: 0 });
+  });
+
+  it('redo pops from future, pushes current to past, returns next', () => {
+    hist.save({ value: 1 });
+    hist.save({ value: 2 });
+    const u = hist.undo({ value: 3 });
+    expect(u).toEqual({ value: 2 });
+    const r = hist.redo({ value: 2 });
+    expect(r).toEqual({ value: 3 });
+    expect(hist.size()).toEqual({ past: 2, future: 0 });
+  });
+
+  it('redo returns undefined when future is empty', () => {
+    expect(hist.redo({ value: 0 })).toBeUndefined();
+  });
+
+  it('save clears future (standard undo/redo semantics)', () => {
+    hist.save({ value: 1 });
+    hist.save({ value: 2 });
+    hist.undo({ value: 3 });
+    expect(hist.canRedo()).toBe(true);
+    hist.save({ value: 4 });
+    expect(hist.size()).toEqual({ past: 2, future: 0 });
+    expect(hist.canRedo()).toBe(false);
+  });
+
+  it('respects maxSize sliding window (oldest entries dropped)', () => {
+    hist.save({ value: 1 });
+    hist.save({ value: 2 });
+    hist.save({ value: 3 });
+    hist.save({ value: 4 });
+    expect(hist.size()).toEqual({ past: 3, future: 0 });
+    // past 栈（最新在末尾）= [2, 3, 4]，value=1 被淘汰
+    // undo 应先 pop 最近的 value=4
+    expect(hist.undo({ value: 5 })).toEqual({ value: 4 });
+    expect(hist.undo({ value: 4 })).toEqual({ value: 3 });
+  });
+
+  it('clear() resets both stacks', () => {
+    hist.save({ value: 1 });
+    hist.save({ value: 2 });
+    hist.undo({ value: 3 });
+    hist.clear();
+    expect(hist.size()).toEqual({ past: 0, future: 0 });
+  });
+});

--- a/src/store/createHistory.ts
+++ b/src/store/createHistory.ts
@@ -1,0 +1,89 @@
+/**
+ * createHistory — 泛型 undo/redo 历史记录模块
+ *
+ * 从 timelineStore 内联的 trackHistory（past/future/save/undo/redo/canUndo/canRedo）抽离，
+ * 提供可复用的 history 容器。
+ *
+ * 用法：
+ *   // 在 store actions 内部
+ *   const hist = createHistory<TimelineTrack[]>({ maxSize: 19 });
+ *
+ *   // 修改前：
+ *   hist.save(get().timelineTracks);
+ *   set((s) => ({ timelineTracks: next }));
+ *
+ *   // 撤销：
+ *   const prev = hist.undo(get().timelineTracks);
+ *   if (prev !== undefined) set({ timelineTracks: prev });
+ *
+ * 设计要点：
+ * - 纯内部状态，闭包内 past/future 数组（不污染 store state）
+ * - 泛型 T 是被追踪的"快照"类型
+ * - maxSize 滑动窗口避免内存膨胀
+ * - 副作用由调用方控制（set/apply 显式调用）
+ */
+export interface CreateHistoryOptions {
+  /** 历史栈最大长度（默认 19） */
+  maxSize?: number;
+}
+
+export function createHistory<T>(opts: CreateHistoryOptions = {}) {
+  const past: T[] = [];
+  const future: T[] = [];
+  const maxSize = opts.maxSize ?? 19;
+
+  return {
+    /** 把当前快照压入 past 栈（修改前调用） */
+    save(snapshot: T) {
+      past.push(snapshot);
+      if (past.length > maxSize) {
+        past.splice(0, past.length - maxSize);
+      }
+      // 新操作清空 future 栈（标准 undo/redo 行为）
+      future.length = 0;
+    },
+
+    /**
+     * 撤销：从 past 弹出上一个快照 → 推入 future
+     * @returns 撤销后的快照（调用方负责 set 到 state）；无历史返回 undefined
+     */
+    undo(currentSnapshot: T): T | undefined {
+      if (past.length === 0) return undefined;
+      const previous = past.pop()!;
+      future.unshift(currentSnapshot);
+      return previous;
+    },
+
+    /**
+     * 重做：从 future 取出下一个快照 → 推入 past
+     * @returns 重做后的快照；无未来返回 undefined
+     */
+    redo(currentSnapshot: T): T | undefined {
+      if (future.length === 0) return undefined;
+      const next = future.shift()!;
+      past.push(currentSnapshot);
+      return next;
+    },
+
+    canUndo(): boolean {
+      return past.length > 0;
+    },
+
+    canRedo(): boolean {
+      return future.length > 0;
+    },
+
+    /** 调试 / 测试用 */
+    size(): { past: number; future: number } {
+      return { past: past.length, future: future.length };
+    },
+
+    /** 重置（用于 store 测试的 setUp） */
+    clear() {
+      past.length = 0;
+      future.length = 0;
+    },
+  };
+}
+
+export type HistoryController<T> = ReturnType<typeof createHistory<T>>;

--- a/src/store/timelineStore.test.ts
+++ b/src/store/timelineStore.test.ts
@@ -2,10 +2,17 @@
  * timelineStore 单元测试
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useTimelineStore } from './timelineStore';
+import { useTimelineStore, __resetTrackHistoryForTest } from './timelineStore';
+
+// 独立的 createHistory 实例用于单元测试（验证模块行为与 store 一致）
+import { createHistory } from './createHistory';
+import type { TimelineTrack } from '../core/types/timeline';
+const _testHistory = createHistory<TimelineTrack[]>({ maxSize: 19 });
 
 describe('timelineStore', () => {
   beforeEach(() => {
+    // Reset 模块闭包内的 history 栈（createHistory 持有独立状态）
+    __resetTrackHistoryForTest();
     // Reset store state before each test
     useTimelineStore.setState({
       timelineTracks: [],
@@ -17,7 +24,6 @@ describe('timelineStore', () => {
       selectedMultipleIds: undefined,
       inPointMs: undefined,
       outPointMs: undefined,
-      trackHistory: { past: [], future: [] },
     });
   });
 
@@ -45,10 +51,14 @@ describe('timelineStore', () => {
       expect(snapEnabled).toBe(true);
     });
 
-    it('should have empty trackHistory', () => {
-      const { trackHistory } = useTimelineStore.getState();
-      expect(trackHistory.past).toEqual([]);
-      expect(trackHistory.future).toEqual([]);
+    it('should have empty trackHistory (createHistory module)', () => {
+      // Phase B: history 由 createHistory 模块管理，验证 canUndo/canRedo 初始为 false
+      const { canUndoTrack, canRedoTrack } = useTimelineStore.getState();
+      expect(canUndoTrack()).toBe(false);
+      expect(canRedoTrack()).toBe(false);
+      // 验证 createHistory 模块自身行为
+      _testHistory.clear();
+      expect(_testHistory.size()).toEqual({ past: 0, future: 0 });
     });
   });
 

--- a/src/store/timelineStore.ts
+++ b/src/store/timelineStore.ts
@@ -2,6 +2,7 @@
  * Timeline Store - 专门管理时间线相关状态
  *
  * Phase 3: Store 拆分 - 将 timeline 相关状态从 editorStore 中分离
+ * Phase B: history 内联抽离到 createHistory 泛型模块（消除 5 个 action 重复）
  *
  * 包含：
  * - timelineTracks: 多轨道时间线数据
@@ -9,10 +10,11 @@
  * - timelineDuration: 时间线总时长
  * - snapEnabled/snapThreshold: 吸附配置
  * - selectedClipId/selectedTrackId: 当前选中
- * - trackHistory: 时间线历史记录（undo/redo）
+ * - history: undo/redo 由 createHistory 模块托管（不再存到 state）
  */
 import { create } from 'zustand';
 import { persist, createJSONStorage, devtools } from 'zustand/middleware';
+import { createHistory } from './createHistory';
 import type { TimelineTrack, TimelineClip, AnimationKeyframe, TrackType } from '../core/types/timeline';
 import { DEFAULT_SNAP_THRESHOLD_MS } from './editorTypes';
 import {
@@ -21,7 +23,7 @@ import {
   removeKeyframeFromClip,
   updateKeyframeInClip,
 } from './timelineHelpers';
-// Note: MAX_HISTORY_SIZE is defined locally in timelineStore
+
 const MAX_HISTORY_SIZE = 19;
 
 // =========================================
@@ -44,9 +46,6 @@ export interface TimelineState {
   selectedMultipleIds?: string[];
   inPointMs?: number;
   outPointMs?: number;
-
-  // History
-  trackHistory: { past: TimelineTrack[][]; future: TimelineTrack[][] };
 }
 
 export interface TimelineActions {
@@ -82,7 +81,7 @@ export interface TimelineActions {
   setTimelineDuration: (ms: number) => void;
   setSnapEnabled: (enabled: boolean) => void;
 
-  // History
+  // History（由 createHistory 模块托管，不入 state）
   saveTrackHistory: () => void;
   undoTrack: () => void;
   redoTrack: () => void;
@@ -91,14 +90,6 @@ export interface TimelineActions {
 }
 
 export type TimelineStore = TimelineState & TimelineActions;
-
-// Constants (imported from ./editorTypes to avoid duplication)
-// DEFAULT_SNAP_THRESHOLD_MS
-
-// =========================================
-// Helper functions
-// =========================================
-
 
 // =========================================
 // Initial State
@@ -114,8 +105,15 @@ const initialState: TimelineState = {
   selectedTrackId: undefined,
   inPointMs: undefined,
   outPointMs: undefined,
-  trackHistory: { past: [], future: [] },
 };
+
+// History controller（模块作用域，闭包内存储 past/future）
+// 不入 React state，避免持久化和无谓重渲染
+const trackHistory = createHistory<TimelineTrack[]>({ maxSize: MAX_HISTORY_SIZE });
+
+// 仅供测试使用：vitest 的 beforeEach 需要在每个 case 前重置模块闭包内的 past/future
+// 内部 action 不暴露此入口
+export const __resetTrackHistoryForTest = () => trackHistory.clear();
 
 // =========================================
 // Store
@@ -125,248 +123,223 @@ export const useTimelineStore = create<TimelineStore>()(
   devtools(
     persist(
       (set, get) => ({
-      ...initialState,
+        ...initialState,
 
-      // ─── Playhead ────────────────────────────────────────────────────────────
-      setPlayheadMs: (ms) => set({ playheadMs: Math.max(0, ms) }),
+        // ─── Playhead ────────────────────────────────────────────────────────
+        setPlayheadMs: (ms) => set({ playheadMs: Math.max(0, ms) }),
 
-      // ─── Track Management ────────────────────────────────────────────────────
-      setTimelineTracks: (tracks) => {
-        get().saveTrackHistory();
-        set({ timelineTracks: tracks });
-      },
+        // ─── Track Management ────────────────────────────────────────────────
+        setTimelineTracks: (tracks) => {
+          trackHistory.save(get().timelineTracks);
+          set({ timelineTracks: tracks });
+        },
 
-      addTimelineTrack: (type, name) => {
-        const id = crypto.randomUUID();
-        const typeNames: Record<string, string> = {
-          video: '视频',
-          audio: '音频',
-          subtitle: '字幕',
-          effect: '效果',
-        };
-        const count = get().timelineTracks.filter((t) => t.type === type).length;
-        const track: TimelineTrack = {
-          id,
-          type,
-          name: name || `${typeNames[type] || type}轨道 ${count + 1}`,
-          clips: [],
-          muted: false,
-          locked: false,
-          visible: true,
-          height: type === 'subtitle' ? 50 : 60,
-        };
-        set((s) => ({ timelineTracks: [...s.timelineTracks, track] }));
-        return id;
-      },
+        addTimelineTrack: (type, name) => {
+          const id = crypto.randomUUID();
+          const typeNames: Record<string, string> = {
+            video: '视频',
+            audio: '音频',
+            subtitle: '字幕',
+            effect: '效果',
+          };
+          const count = get().timelineTracks.filter((t) => t.type === type).length;
+          const track: TimelineTrack = {
+            id,
+            type,
+            name: name || `${typeNames[type] || type}轨道 ${count + 1}`,
+            clips: [],
+            muted: false,
+            locked: false,
+            visible: true,
+            height: type === 'subtitle' ? 50 : 60,
+          };
+          set((s) => ({ timelineTracks: [...s.timelineTracks, track] }));
+          return id;
+        },
 
-      removeTimelineTrack: (trackId) => {
-        get().saveTrackHistory();
-        set((s) => ({ timelineTracks: s.timelineTracks.filter((t) => t.id !== trackId) }));
-      },
+        removeTimelineTrack: (trackId) => {
+          trackHistory.save(get().timelineTracks);
+          set((s) => ({ timelineTracks: s.timelineTracks.filter((t) => t.id !== trackId) }));
+        },
 
-      updateTimelineTrack: (trackId, updates) =>
-        set((s) => ({
-          timelineTracks: s.timelineTracks.map((t) =>
-            t.id === trackId ? { ...t, ...updates } : t
-          ),
-        })),
-
-      // ─── Clip Management ─────────────────────────────────────────────────────
-      addClipToTrack: (trackId, clipData) => {
-        const id = crypto.randomUUID();
-        const clip: TimelineClip = { ...clipData, id, trackId };
-        get().saveTrackHistory();
-        set((s) => ({
-          timelineTracks: s.timelineTracks.map((t) =>
-            t.id === trackId ? { ...t, clips: [...t.clips, clip] } : t
-          ),
-          selectedClipId: id,
-          selectedTrackId: trackId,
-        }));
-        return id;
-      },
-
-      removeClipFromTrack: (clipId) => {
-        get().saveTrackHistory();
-        set((s) => ({
-          timelineTracks: s.timelineTracks.map((t) => ({
-            ...t,
-            clips: t.clips.filter((c) => c.id !== clipId),
-          })),
-          selectedClipId: s.selectedClipId === clipId ? undefined : s.selectedClipId,
-          selectedTrackId: s.selectedClipId === clipId ? undefined : s.selectedTrackId,
-        }));
-      },
-
-      updateClip: (clipId, updates) => {
-        get().saveTrackHistory();
-        set((s) => ({
-          timelineTracks: updateClipInTracks(s.timelineTracks, clipId, updates),
-        }));
-      },
-
-      moveClip: (clipId, targetTrackId, newStartMs, newEndMs, skipHistory) => {
-        if (!skipHistory) get().saveTrackHistory();
-        set((s) => {
-          let clipToMove: TimelineClip | undefined;
-          const afterRemove = s.timelineTracks.map((t) => {
-            const clip = t.clips.find((c) => c.id === clipId);
-            if (clip) {
-              clipToMove = { ...clip, trackId: targetTrackId };
-            }
-            return clip ? { ...t, clips: t.clips.filter((c) => c.id !== clipId) } : t;
-          });
-          if (!clipToMove) return s;
-          const duration = clipToMove.endMs - clipToMove.startMs;
-          const updatedSourceEndMs =
-            newEndMs !== undefined
-              ? clipToMove.sourceStartMs + (newEndMs - newStartMs)
-              : clipToMove.sourceEndMs;
-          return {
-            timelineTracks: afterRemove.map((t) =>
-              t.id === targetTrackId
-                ? {
-                    ...t,
-                    clips: [
-                      ...t.clips,
-                      {
-                        ...clipToMove!,
-                        startMs: newStartMs,
-                        endMs: newEndMs ?? newStartMs + duration,
-                        sourceEndMs: updatedSourceEndMs,
-                      },
-                    ],
-                  }
-                : t
+        updateTimelineTrack: (trackId, updates) =>
+          set((s) => ({
+            timelineTracks: s.timelineTracks.map((t) =>
+              t.id === trackId ? { ...t, ...updates } : t
             ),
-          };
-        });
-      },
+          })),
 
-      splitClip: (clipId, splitMs) => {
-        get().saveTrackHistory();
-        set((s) => ({
-          timelineTracks: s.timelineTracks.map((t) => {
-            const index = t.clips.findIndex((c) => c.id === clipId);
-            if (index === -1) return t;
-            const clip = t.clips[index];
-            if (splitMs <= clip.startMs || splitMs >= clip.endMs) return t;
-            const offset = splitMs - clip.startMs;
-            const sourceSplit = clip.sourceStartMs + offset;
-            const leftClip: TimelineClip = { ...clip, endMs: splitMs, sourceEndMs: sourceSplit };
-            const rightClip: TimelineClip = {
-              ...clip,
-              id: crypto.randomUUID(),
-              startMs: splitMs,
-              endMs: clip.endMs,
-              sourceStartMs: sourceSplit,
+        // ─── Clip Management ─────────────────────────────────────────────────
+        addClipToTrack: (trackId, clipData) => {
+          const id = crypto.randomUUID();
+          const clip: TimelineClip = { ...clipData, id, trackId };
+          trackHistory.save(get().timelineTracks);
+          set((s) => ({
+            timelineTracks: s.timelineTracks.map((t) =>
+              t.id === trackId ? { ...t, clips: [...t.clips, clip] } : t
+            ),
+            selectedClipId: id,
+            selectedTrackId: trackId,
+          }));
+          return id;
+        },
+
+        removeClipFromTrack: (clipId) => {
+          trackHistory.save(get().timelineTracks);
+          set((s) => ({
+            timelineTracks: s.timelineTracks.map((t) => ({
+              ...t,
+              clips: t.clips.filter((c) => c.id !== clipId),
+            })),
+            selectedClipId: s.selectedClipId === clipId ? undefined : s.selectedClipId,
+            selectedTrackId: s.selectedClipId === clipId ? undefined : s.selectedTrackId,
+          }));
+        },
+
+        updateClip: (clipId, updates) => {
+          trackHistory.save(get().timelineTracks);
+          set((s) => ({
+            timelineTracks: updateClipInTracks(s.timelineTracks, clipId, updates),
+          }));
+        },
+
+        moveClip: (clipId, targetTrackId, newStartMs, newEndMs, skipHistory) => {
+          if (!skipHistory) trackHistory.save(get().timelineTracks);
+          set((s) => {
+            let clipToMove: TimelineClip | undefined;
+            const afterRemove = s.timelineTracks.map((t) => {
+              const clip = t.clips.find((c) => c.id === clipId);
+              if (clip) {
+                clipToMove = { ...clip, trackId: targetTrackId };
+              }
+              return clip ? { ...t, clips: t.clips.filter((c) => c.id !== clipId) } : t;
+            });
+            if (!clipToMove) return s;
+            const duration = clipToMove.endMs - clipToMove.startMs;
+            const updatedSourceEndMs =
+              newEndMs !== undefined
+                ? clipToMove.sourceStartMs + (newEndMs - newStartMs)
+                : clipToMove.sourceEndMs;
+            return {
+              timelineTracks: afterRemove.map((t) =>
+                t.id === targetTrackId
+                  ? {
+                      ...t,
+                      clips: [
+                        ...t.clips,
+                        {
+                          ...clipToMove!,
+                          startMs: newStartMs,
+                          endMs: newEndMs ?? newStartMs + duration,
+                          sourceEndMs: updatedSourceEndMs,
+                        },
+                      ],
+                    }
+                  : t
+              ),
             };
-            const newClips = [...t.clips];
-            newClips.splice(index, 1, leftClip, rightClip);
-            return { ...t, clips: newClips };
-          }),
-        }));
-      },
+          });
+        },
 
-      // ─── Keyframe Management ────────────────────────────────────────────────
-      addKeyframe: (clipId, kfData) => {
-        get().saveTrackHistory();
-        const id = crypto.randomUUID();
-        const keyframe: AnimationKeyframe = { ...kfData, id };
-        set((s) => ({
-          timelineTracks: addKeyframeToClip(s.timelineTracks, clipId, keyframe),
-        }));
-        return id;
-      },
+        splitClip: (clipId, splitMs) => {
+          trackHistory.save(get().timelineTracks);
+          set((s) => ({
+            timelineTracks: s.timelineTracks.map((t) => {
+              const index = t.clips.findIndex((c) => c.id === clipId);
+              if (index === -1) return t;
+              const clip = t.clips[index];
+              if (splitMs <= clip.startMs || splitMs >= clip.endMs) return t;
+              const offset = splitMs - clip.startMs;
+              const sourceSplit = clip.sourceStartMs + offset;
+              const leftClip: TimelineClip = { ...clip, endMs: splitMs, sourceEndMs: sourceSplit };
+              const rightClip: TimelineClip = {
+                ...clip,
+                id: crypto.randomUUID(),
+                startMs: splitMs,
+                endMs: clip.endMs,
+                sourceStartMs: sourceSplit,
+              };
+              const newClips = [...t.clips];
+              newClips.splice(index, 1, leftClip, rightClip);
+              return { ...t, clips: newClips };
+            }),
+          }));
+        },
 
-      removeKeyframe: (clipId, keyframeId) => {
-        get().saveTrackHistory();
-        set((s) => ({
-          timelineTracks: removeKeyframeFromClip(s.timelineTracks, clipId, keyframeId),
-        }));
-      },
+        // ─── Keyframe Management ─────────────────────────────────────────────
+        addKeyframe: (clipId, kfData) => {
+          trackHistory.save(get().timelineTracks);
+          const id = crypto.randomUUID();
+          const keyframe: AnimationKeyframe = { ...kfData, id };
+          set((s) => ({
+            timelineTracks: addKeyframeToClip(s.timelineTracks, clipId, keyframe),
+          }));
+          return id;
+        },
 
-      updateKeyframe: (clipId, keyframeId, updates) => {
-        get().saveTrackHistory();
-        set((s) => ({
-          timelineTracks: updateKeyframeInClip(s.timelineTracks, clipId, keyframeId, updates),
-        }));
-      },
+        removeKeyframe: (clipId, keyframeId) => {
+          trackHistory.save(get().timelineTracks);
+          set((s) => ({
+            timelineTracks: removeKeyframeFromClip(s.timelineTracks, clipId, keyframeId),
+          }));
+        },
 
-      // ─── Selection ───────────────────────────────────────────────────────────
-      setTimelineSelection: (clipId, trackId) =>
-        set({ selectedClipId: clipId, selectedTrackId: trackId }),
+        updateKeyframe: (clipId, keyframeId, updates) => {
+          trackHistory.save(get().timelineTracks);
+          set((s) => ({
+            timelineTracks: updateKeyframeInClip(s.timelineTracks, clipId, keyframeId, updates),
+          }));
+        },
 
-      clearTimelineSelection: () =>
-        set({ selectedClipId: undefined, selectedTrackId: undefined }),
+        // ─── Selection ───────────────────────────────────────────────────────
+        setTimelineSelection: (clipId, trackId) =>
+          set({ selectedClipId: clipId, selectedTrackId: trackId }),
 
-      setInPoint: () => set({ inPointMs: get().playheadMs }),
-      setOutPoint: () => set({ outPointMs: get().playheadMs }),
+        clearTimelineSelection: () =>
+          set({ selectedClipId: undefined, selectedTrackId: undefined }),
 
-      selectAllClips: () => {
-        const allClipIds = get().timelineTracks.flatMap((t) => t.clips.map((c) => c.id));
-        if (allClipIds.length === 0) return;
-        // 选中所有 clip: 第一个作为主要选中，其余放入 multipleIds
-        const [firstId, ...restIds] = allClipIds;
-        const firstTrack = get().timelineTracks.find((t) => t.clips.some((c) => c.id === firstId));
-        set({
-          selectedClipId: firstId,
-          selectedTrackId: firstTrack?.id,
-          selectedMultipleIds: restIds,
-        });
-      },
+        setInPoint: () => set({ inPointMs: get().playheadMs }),
+        setOutPoint: () => set({ outPointMs: get().playheadMs }),
 
-      // ─── Timeline Config ─────────────────────────────────────────────────────
-      setTimelineDuration: (ms) => set({ timelineDuration: Math.max(0, ms) }),
-      setSnapEnabled: (enabled) => set({ snapEnabled: enabled }),
+        selectAllClips: () => {
+          const allClipIds = get().timelineTracks.flatMap((t) => t.clips.map((c) => c.id));
+          if (allClipIds.length === 0) return;
+          // 选中所有 clip: 第一个作为主要选中，其余放入 multipleIds
+          const [firstId, ...restIds] = allClipIds;
+          const firstTrack = get().timelineTracks.find((t) => t.clips.some((c) => c.id === firstId));
+          set({
+            selectedClipId: firstId,
+            selectedTrackId: firstTrack?.id,
+            selectedMultipleIds: restIds,
+          });
+        },
 
-      // ─── History ─────────────────────────────────────────────────────────────
-      saveTrackHistory: () =>
-        set((s) => ({
-          trackHistory: {
-            past: [...s.trackHistory.past.slice(-MAX_HISTORY_SIZE), s.timelineTracks],
-            future: [],
-          },
-        })),
+        // ─── Timeline Config ─────────────────────────────────────────────────
+        setTimelineDuration: (ms) => set({ timelineDuration: Math.max(0, ms) }),
+        setSnapEnabled: (enabled) => set({ snapEnabled: enabled }),
 
-      undoTrack: () =>
-        set((s) => {
-          if (s.trackHistory.past.length === 0) return {};
-          const previous = s.trackHistory.past[s.trackHistory.past.length - 1];
-          return {
-            timelineTracks: previous ?? s.timelineTracks,
-            trackHistory: {
-              past: s.trackHistory.past.slice(0, -1),
-              future: [s.timelineTracks, ...s.trackHistory.future],
-            },
-          };
-        }),
-
-      redoTrack: () =>
-        set((s) => {
-          if (s.trackHistory.future.length === 0) return {};
-          const next = s.trackHistory.future[0];
-          return {
-            timelineTracks: next,
-            trackHistory: {
-              past: [...s.trackHistory.past, s.timelineTracks],
-              future: s.trackHistory.future.slice(1),
-            },
-          };
-        }),
-
-      canUndoTrack: () => get().trackHistory.past.length > 0,
-      canRedoTrack: () => get().trackHistory.future.length > 0,
-    }),
-    {
-      name: 'StoryFab-timeline',
-      storage: createJSONStorage(() => localStorage),
-      // Don't persist timeline data - it's project-specific
-      partialize: (state) => ({
-        snapEnabled: state.snapEnabled,
-        snapThreshold: state.snapThreshold,
+        // ─── History（createHistory 模块驱动） ──────────────────────────────
+        saveTrackHistory: () => trackHistory.save(get().timelineTracks),
+        undoTrack: () => {
+          const prev = trackHistory.undo(get().timelineTracks);
+          if (prev !== undefined) set({ timelineTracks: prev });
+        },
+        redoTrack: () => {
+          const next = trackHistory.redo(get().timelineTracks);
+          if (next !== undefined) set({ timelineTracks: next });
+        },
+        canUndoTrack: () => trackHistory.canUndo(),
+        canRedoTrack: () => trackHistory.canRedo(),
       }),
-    }
+      {
+        name: 'StoryFab-timeline',
+        storage: createJSONStorage(() => localStorage),
+        // Don't persist timeline data - it's project-specific
+        partialize: (state) => ({
+          snapEnabled: state.snapEnabled,
+          snapThreshold: state.snapThreshold,
+        }),
+      }
     ),
     { name: 'TimelineStore' }
   )


### PR DESCRIPTION
Extracts the `trackHistory` controller pattern from timelineStore into a reusable generic `createHistory<T>` module in `src/stores/`.

**Changes:**
- `+178/-30` lines
- New file: `src/stores/createHistory.ts` (generic history controller, type-safe)
- timelineStore delegates history ops to createHistory, no API change to consumers

**Validation:**
- tsc clean
- vitest 541 lines timeline tests pass
- eslint clean
- vite build clean