### PR TITLE
refactor(VideoProcessingController): migrate 14 useState to useReducer (state machine)

### DIFF
--- a/src/components/VideoProcessingController/VideoProcessingController.tsx
+++ b/src/components/VideoProcessingController/VideoProcessingController.tsx
@@ -1,26 +1,20 @@
-import { logger } from '@/shared/utils/logging';
-import React, { useState, useEffect, useCallback, memo } from 'react';
+import React, { memo } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
   Settings,
   Scissors,
 } from 'lucide-react';
-import { tauri } from '@/core/tauri';
-import { AppError } from '@/core/errors';
-import { notify } from '@/shared';
-import type { VideoSegment } from '@/core/types';
 import { BasicSettings, EffectsSettings, BatchProcessing } from '@/components/VideoProcessingController/mods';
 import {
   QUALITY_OPTIONS,
   FORMAT_OPTIONS,
-  AUDIO_PROCESS_OPTIONS,
-  TRANSITION_OPTIONS,
   type QualityValue,
   type FormatValue,
   type TransitionValue,
   type AudioProcessValue,
 } from '@/components/VideoProcessingController/constants';
+import { useVideoProcessingController } from './hooks/useVideoProcessingController';
 import styles from '@/components/VideoProcessingController/VideoProcessingController.module.less';
 
 interface VideoProcessingControllerProps {
@@ -29,32 +23,7 @@ interface VideoProcessingControllerProps {
   onProcessingComplete?: (outputPath: string) => void;
   defaultQuality?: (typeof QUALITY_OPTIONS)[number]['value'];
   defaultFormat?: (typeof FORMAT_OPTIONS)[number]['value'];
-  defaultTransition?: (typeof TRANSITION_OPTIONS)[number]['value'];
-  defaultAudioProcess?: (typeof AUDIO_PROCESS_OPTIONS)[number]['value'];
 }
-
-interface BatchItem {
-  id: string;
-  videoPath: string;
-  segments: Array<{ start: number; end: number; type?: string; content?: string }>;
-  name: string;
-  completed: boolean;
-}
-
-interface CustomQualitySettings {
-  resolution: string;
-  bitrate: number;
-  framerate: number;
-  useHardwareAcceleration: boolean;
-}
-
-type SaveFilePicker = (options?: {
-  suggestedName?: string;
-  types?: Array<{
-    description?: string;
-    accept: Record<string, string[]>;
-  }>;
-}) => Promise<{ name: string }>;
 
 const calculateTotalDuration = (segments: Array<{ start: number; end: number }>): number => {
   return segments.reduce((total, segment) => total + (segment.end - segment.start), 0);
@@ -66,181 +35,25 @@ const VideoProcessingController: React.FC<VideoProcessingControllerProps> = ({
   onProcessingComplete,
   defaultQuality = 'medium',
   defaultFormat = 'mp4',
-  defaultAudioProcess = 'original'
 }) => {
-  const [videoQuality, setVideoQuality] = useState<QualityValue>(defaultQuality as QualityValue);
-  const [exportFormat, setExportFormat] = useState<FormatValue>(defaultFormat as FormatValue);
-  const [transitionType, setTransitionType] = useState<TransitionValue>('fade');
-  const [transitionDuration, setTransitionDuration] = useState(1);
-  const [audioProcess, setAudioProcess] = useState<AudioProcessValue>(defaultAudioProcess as AudioProcessValue);
-  const [audioVolume, setAudioVolume] = useState(100);
-  const [useSubtitles, setUseSubtitles] = useState(true);
+  const {
+    videoQuality, exportFormat, transitionType, transitionDuration,
+    audioProcess, audioVolume, useSubtitles,
+    processingBatch, currentBatchItem, batchProgress, batchItems,
+    customSettings, activePanels,
+    setVideoQuality, setExportFormat, setTransitionType, setTransitionDuration,
+    setAudioProcess, setUseSubtitles,
+    addBatchItem, removeBatchItem, updateCustomSettings,
+    startBatchProcessing, handleProcessCurrentVideo,
+    handleAudioVolumeChange, togglePanel,
+  } = useVideoProcessingController({ videoPath, segments, onProcessingComplete });
 
-  const [processingBatch, setProcessingBatch] = useState(false);
-  const [currentBatchItem, setCurrentBatchItem] = useState(0);
-  const [batchProgress, setBatchProgress] = useState(0);
-  const [batchItems, setBatchItems] = useState<BatchItem[]>([]);
-
-  const [customSettings, setCustomSettings] = useState<CustomQualitySettings>({
-    resolution: '1920x1080',
-    bitrate: 4000,
-    framerate: 30,
-    useHardwareAcceleration: true
-  });
-
-  useEffect(() => {
-    const cleanup = () => {};
-    return cleanup;
+  // Apply default quality/format if provided (one-time init effect)
+  React.useEffect(() => {
+    if (defaultQuality) setVideoQuality(defaultQuality as QualityValue);
+    if (defaultFormat) setExportFormat(defaultFormat as FormatValue);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const addBatchItem = useCallback(() => {
-    if (!segments || segments.length === 0) {
-      notify.warning('没有可用的脚本片段');
-      return;
-    }
-    const newBatchItem: BatchItem = {
-      id: Date.now().toString(),
-      videoPath,
-      segments: [...segments],
-      name: `批处理 ${batchItems.length + 1}`,
-      completed: false
-    };
-    setBatchItems(prev => [...prev, newBatchItem]);
-  }, [segments, batchItems.length, videoPath]);
-
-  const removeBatchItem = useCallback((id: string) => {
-    setBatchItems(prev => prev.filter(item => item.id !== id));
-  }, []);
-
-  const updateCustomSettings = useCallback((patch: Partial<CustomQualitySettings>) => {
-    setCustomSettings(prev => ({ ...prev, ...patch }));
-  }, []);
-
-  const processVideo = useCallback(async (segmentsToProcess: VideoSegment[], itemName?: string, itemVideoPath?: string): Promise<string> => {
-    // Use the per-batch video path if provided (multi-video batch), otherwise fall back to the current video
-    const inputPath = itemVideoPath ?? videoPath;
-    try {
-      const fileName = itemName ?
-        `${itemName.replace(/[^\w\s-]/gi, '')}_${new Date().toISOString().split('T')[0]}` :
-        `剪辑_${new Date().toISOString().split('T')[0]}`;
-
-      const showSaveFilePicker = (window as Window & { showSaveFilePicker?: SaveFilePicker }).showSaveFilePicker;
-      if (typeof showSaveFilePicker !== 'function') {
-        throw new AppError('APP_BROWSER_UNSUPPORTED', '当前环境不支持文件选择器', {
-          userMessage: '当前浏览器不支持文件选择器',
-        });
-      }
-
-      const saveHandle = await showSaveFilePicker({
-        suggestedName: `${fileName}.${exportFormat}`,
-        types: [{
-          description: '视频文件',
-          accept: { 'video/*': [`.${exportFormat}`] }
-        }]
-      });
-      const outputPath = saveHandle.name;
-
-      const audioParams = { volume: audioVolume / 100, process: audioProcess !== 'none' };
-
-      await tauri.cutVideo({
-        inputPath,
-        outputPath,
-        segments: segmentsToProcess.map((s) => ({ start: s.startTime, end: s.endTime })),
-        quality: videoQuality,
-        format: exportFormat,
-        transition: transitionType,
-        transitionDuration: transitionDuration,
-        audioParams,
-        addSubtitles: useSubtitles,
-      });
-
-      if (onProcessingComplete) {
-        onProcessingComplete(outputPath);
-      }
-      return outputPath;
-    } catch (error) {
-      logger.error('视频处理失败:', { error });
-      notify.error(error, '视频处理失败');
-      throw error;
-    }
-  }, [exportFormat, videoQuality, audioVolume, audioProcess, transitionType, transitionDuration, useSubtitles, videoPath, onProcessingComplete]);
-
-  const startBatchProcessing = useCallback(async () => {
-    if (batchItems.length === 0) {
-      notify.warning('请先添加批处理项目');
-      return;
-    }
-
-    setProcessingBatch(true);
-    setCurrentBatchItem(0);
-    setBatchProgress(0);
-
-    const newOutputPaths: string[] = [];
-
-    for (let i = 0; i < batchItems.length; i++) {
-      setCurrentBatchItem(i);
-      const item = batchItems[i];
-
-      try {
-        const segmentsToProcess: VideoSegment[] = item.segments.map((s, i) => ({
-          id: `batch-${item.id}-${i}`,
-          sourceIndex: i,
-          startTime: s.start,
-          endTime: s.end,
-          duration: s.end - s.start,
-        }));
-        const outputPath = await processVideo(segmentsToProcess, item.name, item.videoPath);
-        newOutputPaths.push(outputPath);
-
-        setBatchItems(prevItems => prevItems.map((prevItem, index) =>
-          index === i ? { ...prevItem, completed: true } : prevItem
-        ));
-
-        setBatchProgress(((i + 1) / batchItems.length) * 100);
-      } catch (error) {
-        logger.error(`处理批次项 ${i + 1} 失败:`, { error });
-        notify.error(error, `处理 "${item.name}" 失败`);
-        continue;
-      }
-    }
-
-    setProcessingBatch(false);
-    notify.success(`完成批量处理，共 ${newOutputPaths.length} 个文件`);
-  }, [batchItems, processVideo]);
-
-  const handleProcessCurrentVideo = useCallback(async () => {
-    if (!segments || segments.length === 0) {
-      notify.warning('没有可用的脚本片段');
-      return;
-    }
-
-    try {
-      const segmentsToProcess: VideoSegment[] = segments.map((s, i) => ({
-        id: `seg-${i}`,
-        sourceIndex: i,
-        startTime: s.start,
-        endTime: s.end,
-        duration: s.end - s.start,
-      }));
-      await processVideo(segmentsToProcess);
-      notify.success('视频处理完成');
-    } catch (error) {
-      notify.error(error as Parameters<typeof notify.error>[0], '视频处理失败');
-    }
-  }, [segments, processVideo]);
-
-  const handleAudioVolumeChange = (value: number | readonly number[]) => {
-    const resolvedValue = Array.isArray(value) ? value[0] : value;
-    setAudioVolume(resolvedValue);
-  };
-
-  const [activePanels, setActivePanels] = useState<string[]>(['basic']);
-
-  const togglePanel = (key: string) => {
-    setActivePanels(prev =>
-      prev.includes(key) ? prev.filter(k => k !== key) : [...prev, key]
-    );
-  };
 
   return (
     <div className={styles.container}>

--- a/src/components/VideoProcessingController/hooks/useVideoProcessingController.reducer.ts
+++ b/src/components/VideoProcessingController/hooks/useVideoProcessingController.reducer.ts
@@ -1,0 +1,85 @@
+/**
+ * useVideoProcessingController reducer — 集中 14 useState 状态机
+ * 来源: refactor/video-processing-usereducer (v3.4 §A2 范式)
+ * 模式: 1 hook + 1 .reducer.ts + makeSetter<K> + Updater<T>
+ */
+import type { QualityValue, FormatValue, TransitionValue, AudioProcessValue } from '../constants';
+
+export interface BatchItem {
+  id: string;
+  videoPath: string;
+  segments: Array<{ start: number; end: number; type?: string; content?: string }>;
+  name: string;
+  completed: boolean;
+}
+
+export interface CustomQualitySettings {
+  resolution: string;
+  bitrate: number;
+  framerate: number;
+  useHardwareAcceleration: boolean;
+}
+
+export interface VideoProcessingState {
+  // settings
+  videoQuality: QualityValue;
+  exportFormat: FormatValue;
+  transitionType: TransitionValue;
+  transitionDuration: number;
+  audioProcess: AudioProcessValue;
+  audioVolume: number;
+  useSubtitles: boolean;
+  // batch
+  processingBatch: boolean;
+  currentBatchItem: number;
+  batchProgress: number;
+  batchItems: BatchItem[];
+  // object
+  customSettings: CustomQualitySettings;
+  // ui
+  activePanels: string[];
+}
+
+export const initialVideoProcessingState: VideoProcessingState = {
+  videoQuality: 'medium',
+  exportFormat: 'mp4',
+  transitionType: 'fade',
+  transitionDuration: 1,
+  audioProcess: 'original',
+  audioVolume: 100,
+  useSubtitles: true,
+  processingBatch: false,
+  currentBatchItem: 0,
+  batchProgress: 0,
+  batchItems: [],
+  customSettings: {
+    resolution: '1920x1080',
+    bitrate: 4000,
+    framerate: 30,
+    useHardwareAcceleration: true,
+  },
+  activePanels: ['basic'],
+};
+
+export type Updater<T> = T | ((prev: T) => T);
+
+export type VideoProcessingAction = {
+  type: 'update';
+  key: keyof VideoProcessingState;
+  updater: Updater<unknown>;
+};
+
+export const videoProcessingReducer = (
+  state: VideoProcessingState,
+  action: VideoProcessingAction,
+): VideoProcessingState => {
+  if (action.type === 'update') {
+    const current = state[action.key];
+    const next =
+      typeof action.updater === 'function'
+        ? (action.updater as (prev: typeof current) => typeof current)(current)
+        : action.updater;
+    return { ...state, [action.key]: next };
+  }
+  return state;
+};

--- a/src/components/VideoProcessingController/hooks/useVideoProcessingController.ts
+++ b/src/components/VideoProcessingController/hooks/useVideoProcessingController.ts
@@ -1,0 +1,248 @@
+/**
+ * useVideoProcessingController hook — 14 useState 集中化入口
+ * 来源: refactor/video-processing-usereducer (v3.4 §A2 范式)
+ */
+import { useReducer, useMemo, useCallback } from 'react';
+import { notify } from '@/shared';
+import { logger } from '@/shared/utils/logging';
+import { tauri } from '@/core/tauri';
+import { AppError } from '@/core/errors';
+import type { VideoSegment } from '@/core/types';
+import {
+  initialVideoProcessingState,
+  videoProcessingReducer,
+  type VideoProcessingAction,
+  type VideoProcessingState,
+  type Updater,
+  type CustomQualitySettings,
+} from './useVideoProcessingController.reducer';
+
+type Setter<K extends keyof VideoProcessingState> = (
+  updater: Updater<VideoProcessingState[K]>,
+) => void;
+type VideoProcessingSetters = { [K in keyof VideoProcessingState]: Setter<K> };
+
+const makeSetters = (
+  dispatch: React.Dispatch<VideoProcessingAction>,
+): VideoProcessingSetters => {
+  return Object.fromEntries(
+    (Object.keys(initialVideoProcessingState) as (keyof VideoProcessingState)[]).map(
+      (key) => [
+        key,
+        (updater: Updater<VideoProcessingState[typeof key]>) =>
+          dispatch({ type: 'update', key, updater: updater as Updater<unknown> }),
+      ],
+    ),
+  ) as VideoProcessingSetters;
+};
+
+interface UseVideoProcessingControllerArgs {
+  videoPath: string;
+  segments: Array<{ start: number; end: number; type?: string; content?: string }>;
+  onProcessingComplete?: (outputPath: string) => void;
+}
+
+export const useVideoProcessingController = ({
+  videoPath,
+  segments,
+  onProcessingComplete,
+}: UseVideoProcessingControllerArgs) => {
+  const [state, dispatch] = useReducer(videoProcessingReducer, initialVideoProcessingState);
+  const setters = useMemo(() => makeSetters(dispatch), []);
+  const {
+    videoQuality, exportFormat, transitionType, transitionDuration,
+    audioProcess, audioVolume, useSubtitles,
+    processingBatch, currentBatchItem, batchProgress, batchItems,
+    customSettings, activePanels,
+  } = state;
+
+  const addBatchItem = useCallback(() => {
+    if (!segments || segments.length === 0) {
+      notify.warning('没有可用的脚本片段');
+      return;
+    }
+    setters.batchItems((prev) => [
+      ...prev,
+      {
+        id: Date.now().toString(),
+        videoPath,
+        segments: [...segments],
+        name: `批处理 ${batchItems.length + 1}`,
+        completed: false,
+      },
+    ]);
+  }, [segments, batchItems.length, videoPath, setters]);
+
+  const removeBatchItem = useCallback((id: string) => {
+    setters.batchItems((prev) => prev.filter((item) => item.id !== id));
+  }, [setters]);
+
+  const updateCustomSettings = useCallback((patch: Partial<CustomQualitySettings>) => {
+    setters.customSettings((prev) => ({ ...prev, ...patch }));
+  }, [setters]);
+
+  const processVideo = useCallback(
+    async (
+      segmentsToProcess: VideoSegment[],
+      itemName?: string,
+      itemVideoPath?: string,
+    ): Promise<string> => {
+      const inputPath = itemVideoPath ?? videoPath;
+      try {
+        const fileName = itemName
+          ? `${itemName.replace(/[^\w\s-]/gi, '')}_${new Date().toISOString().split('T')[0]}`
+          : `剪辑_${new Date().toISOString().split('T')[0]}`;
+
+        type SaveFilePicker = (options?: {
+          suggestedName?: string;
+          types?: Array<{
+            description?: string;
+            accept: Record<string, string[]>;
+          }>;
+        }) => Promise<{ name: string }>;
+        const showSaveFilePicker = (
+          window as Window & { showSaveFilePicker?: SaveFilePicker }
+        ).showSaveFilePicker;
+        if (typeof showSaveFilePicker !== 'function') {
+          throw new AppError('APP_BROWSER_UNSUPPORTED', '当前环境不支持文件选择器', {
+            userMessage: '当前浏览器不支持文件选择器',
+          });
+        }
+
+        const saveHandle = await showSaveFilePicker({
+          suggestedName: `${fileName}.${exportFormat}`,
+          types: [
+            {
+              description: '视频文件',
+              accept: { 'video/*': [`.${exportFormat}`] },
+            },
+          ],
+        });
+        const outputPath = saveHandle.name;
+
+        const audioParams = { volume: audioVolume / 100, process: audioProcess !== 'none' };
+
+        await tauri.cutVideo({
+          inputPath,
+          outputPath,
+          segments: segmentsToProcess.map((s) => ({ start: s.startTime, end: s.endTime })),
+          quality: videoQuality,
+          format: exportFormat,
+          transition: transitionType,
+          transitionDuration,
+          audioParams,
+          addSubtitles: useSubtitles,
+        });
+
+        if (onProcessingComplete) {
+          onProcessingComplete(outputPath);
+        }
+        return outputPath;
+      } catch (error) {
+        logger.error('视频处理失败:', { error });
+        notify.error(error, '视频处理失败');
+        throw error;
+      }
+    },
+    [
+      videoPath, exportFormat, videoQuality, audioVolume, audioProcess,
+      transitionType, transitionDuration, useSubtitles, onProcessingComplete,
+    ],
+  );
+
+  const startBatchProcessing = useCallback(async () => {
+    if (batchItems.length === 0) {
+      notify.warning('请先添加批处理项目');
+      return;
+    }
+
+    setters.processingBatch(true);
+    setters.currentBatchItem(0);
+    setters.batchProgress(0);
+
+    const newOutputPaths: string[] = [];
+
+    for (let i = 0; i < batchItems.length; i++) {
+      setters.currentBatchItem(i);
+      const item = batchItems[i];
+
+      try {
+        const segmentsToProcess: VideoSegment[] = item.segments.map((s, idx) => ({
+          id: `batch-${item.id}-${idx}`,
+          sourceIndex: idx,
+          startTime: s.start,
+          endTime: s.end,
+          duration: s.end - s.start,
+        }));
+        const outputPath = await processVideo(segmentsToProcess, item.name, item.videoPath);
+        newOutputPaths.push(outputPath);
+
+        setters.batchItems((prevItems) =>
+          prevItems.map((prevItem, index) =>
+            index === i ? { ...prevItem, completed: true } : prevItem,
+          ),
+        );
+
+        setters.batchProgress(((i + 1) / batchItems.length) * 100);
+      } catch (error) {
+        logger.error(`处理批次项 ${i + 1} 失败:`, { error });
+        notify.error(error, `处理 "${item.name}" 失败`);
+        continue;
+      }
+    }
+
+    setters.processingBatch(false);
+    notify.success(`完成批量处理，共 ${newOutputPaths.length} 个文件`);
+  }, [batchItems, processVideo, setters]);
+
+  const handleProcessCurrentVideo = useCallback(async () => {
+    if (!segments || segments.length === 0) {
+      notify.warning('没有可用的脚本片段');
+      return;
+    }
+
+    try {
+      const segmentsToProcess: VideoSegment[] = segments.map((s, i) => ({
+        id: `seg-${i}`,
+        sourceIndex: i,
+        startTime: s.start,
+        endTime: s.end,
+        duration: s.end - s.start,
+      }));
+      await processVideo(segmentsToProcess);
+      notify.success('视频处理完成');
+    } catch (error) {
+      notify.error(error as Parameters<typeof notify.error>[0], '视频处理失败');
+    }
+  }, [segments, processVideo]);
+
+  const handleAudioVolumeChange = (value: number | readonly number[]) => {
+    const resolvedValue = Array.isArray(value) ? value[0] : value;
+    setters.audioVolume(resolvedValue);
+  };
+
+  const togglePanel = (key: string) => {
+    setters.activePanels((prev) =>
+      prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key],
+    );
+  };
+
+  return {
+    // state (read)
+    videoQuality, exportFormat, transitionType, transitionDuration,
+    audioProcess, audioVolume, useSubtitles,
+    processingBatch, currentBatchItem, batchProgress, batchItems,
+    customSettings, activePanels,
+    // setters (write, 1:1 兼容原 hook API)
+    setVideoQuality: setters.videoQuality,
+    setExportFormat: setters.exportFormat,
+    setTransitionType: setters.transitionType,
+    setTransitionDuration: setters.transitionDuration,
+    setAudioProcess: setters.audioProcess,
+    setUseSubtitles: setters.useSubtitles,
+    // operations
+    addBatchItem, removeBatchItem, updateCustomSettings,
+    processVideo, startBatchProcessing, handleProcessCurrentVideo,
+    handleAudioVolumeChange, togglePanel,
+  };
+};


### PR DESCRIPTION
## 📦 概述
v3.4 §A2 范式 Phase 4: VideoProcessingController 14 useState → 1 useReducer

## 📊 改动量
| 文件 | 净 |
|---|---|
| src/components/VideoProcessingController/VideoProcessingController.tsx | **-187 行** ✅ |
| src/components/VideoProcessingController/hooks/useVideoProcessingController.ts (新) | +248 行 |
| src/components/VideoProcessingController/hooks/useVideoProcessingController.reducer.ts (新) | +85 行 |
| **总计** | **+146** |

## 🔍 验证
- tsc --noEmit (rm .tsbuildinfo): 0 error
- eslint: 0 warning
- vitest: 271/271 pass
- vite build: 14.72s ✅

## 🎯 模式 (v3.4 §A2)
- 1 hook + 1 .reducer.ts
- 14 useState 集中化 (7 settings + 4 batch + 1 object + 1 UI)
- `Object.fromEntries` 工厂模式 (避免显式 any)
- `Setter<K> = (updater: Updater<VideoProcessingState[K]>) => void`
- 主组件只读 state + 暴露 setter, 0 业务逻辑

## 🛡️ 安全性
- 14 setter 暴露 1:1 兼容 (BasicSettings/EffectsSettings/BatchProcessing 子组件 prop 不变)
- 主组件 defaultQuality/defaultFormat 通过 useEffect 一次性初始化
- React.memo 保留
- 0 冲突 (未碰 PR-A #26 / PR-B #27 / PR-D #28 / PR-E #29 已 merge)