### PR TITLE
refactor(VideoEditor): migrate 15 useState to useReducer (state machine)

### DIFF
--- a/src/components/VideoEditor/VideoEditor.tsx
+++ b/src/components/VideoEditor/VideoEditor.tsx
@@ -1,24 +1,16 @@
-import { logger } from '../../shared/utils/logging';
-import React, { useState, useCallback, useEffect, memo, useRef } from 'react';
+import React, { memo } from 'react';
 import { Card } from '../ui/card';
-import { tauri } from '../../core/tauri/TauriBridge';
-import { convertFileSrc } from '@tauri-apps/api/core';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
-import { save } from '@tauri-apps/plugin-dialog';
 import { ScriptSegment } from '@/types';
-import { notify } from '@/shared';
 
 import VideoPlayer from '@/components/VideoPlayer/VideoPlayer';
 import Timeline from './Timeline';
 import SegmentDetails from './SegmentDetails';
 import EditorControls from './EditorControls';
-import ExportSettings, { ExportSettingsState } from './ExportSettings';
+import ExportSettings from './ExportSettings';
 import PreviewModal from './PreviewModal';
+import { useVideoEditorPage } from './hooks/useVideoEditorPage';
 
 import styles from '@/components/VideoEditor/VideoEditor.module.less';
-
-// 全局变量存储视频时长，用于拖拽边界计算
-let globalVideoDuration = 0;
 
 interface VideoEditorProps {
   videoPath: string;
@@ -27,270 +19,17 @@ interface VideoEditorProps {
 }
 
 const VideoEditor: React.FC<VideoEditorProps> = ({ videoPath, segments, onEditComplete }) => {
-  // 播放器状态
-  const [, _setCurrentTime] = useState(0);
-  const [duration, _setDuration] = useState(0);
-  const [isPlaying, _setIsPlaying] = useState(false);
-
-  // 处理状态
-  const [processing, setProcessing] = useState(false);
-  const [processProgress, setProcessProgress] = useState(0);
-
-  // 片段状态
-  const [selectedSegment, setSelectedSegment] = useState<ScriptSegment | null>(null);
-  const [editedSegments, setEditedSegments] = useState<ScriptSegment[]>(segments);
-
-  // 导出设置状态
-  const [exportSettings, setExportSettings] = useState<ExportSettingsState>({
-    videoQuality: 'medium',
-    exportFormat: 'mp4',
-    transitionType: 'fade',
-    transitionDuration: 1,
-    audioVolume: 100,
-    useSubtitles: true,
-  });
-  const [settingsTab, setSettingsTab] = useState('general');
-  const [showSettingsModal, setShowSettingsModal] = useState(false);
-
-  // 预览状态
-  const [showPreviewModal, setShowPreviewModal] = useState(false);
-  const [previewSegment, setPreviewSegment] = useState<ScriptSegment | null>(null);
-  const [previewLoading, setPreviewLoading] = useState(false);
-  const [previewUrl, setPreviewUrl] = useState('');
-
-  // 拖拽状态
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragType, setDragType] = useState<'move' | 'start' | 'end' | null>(null);
-  const [dragSegmentId, setDragSegmentId] = useState<string | null>(null);
-
-  // 拖拽状态用 ref 存储，避免 useCallback 依赖导致重新绑定
-  const dragStateRef = useRef({ isDragging: false, dragSegmentId: null as string | null, dragType: null as 'move' | 'start' | 'end' | null, duration: 0 });
-
-  // 同步 dragStateRef
-  useEffect(() => {
-    dragStateRef.current = { isDragging, dragSegmentId, dragType, duration };
-  }, [isDragging, dragSegmentId, dragType, duration]);
-
-  // 同步传入的 segments
-  useEffect(() => {
-    setEditedSegments(segments);
-  }, [segments]);
-
-  // 更新全局视频时长
-  useEffect(() => {
-    globalVideoDuration = duration;
-  }, [duration]);
-
-  // 清理临时文件
-  useEffect(() => {
-    return () => {
-      if (previewUrl && previewUrl.includes('temp')) {
-        tauri.cleanTempFile(previewUrl).catch((e) => logger.error('clean_temp_file error:', { error: e }));
-      }
-    };
-  }, [previewUrl]);
-
-  // 处理时间更新
-  const handleTimeUpdate = useCallback((time: number) => {
-    _setCurrentTime(time);
-  }, []);
-
-  // 点击片段
-  const handleSegmentClick = useCallback((segment: ScriptSegment) => {
-    _setCurrentTime(segment.startTime);
-    setSelectedSegment(segment);
-  }, []);
-
-  // 预览片段
-  const handlePreviewSegment = useCallback(async (segment: ScriptSegment) => {
-    setPreviewLoading(true);
-    setPreviewSegment(segment);
-    setShowPreviewModal(true);
-
-    try {
-      const tempPath = await tauri.generatePreview({
-        inputPath: videoPath,
-        segment: {
-          start: segment.startTime,
-          end: segment.endTime,
-        },
-      });
-
-      const fileUrl = convertFileSrc(tempPath);
-      setPreviewUrl(fileUrl);
-    } catch (error) {
-      logger.error('生成预览失败:', { error });
-      notify.error(error, '生成预览失败');
-    } finally {
-      setPreviewLoading(false);
-    }
-  }, [videoPath]);
-
-  // 关闭预览
-  const handleClosePreview = useCallback(() => {
-    setShowPreviewModal(false);
-    setPreviewUrl('');
-    setPreviewSegment(null);
-  }, []);
-
-  // 显示导出设置
-  const handleShowSettings = useCallback(() => {
-    setShowSettingsModal(true);
-  }, []);
-
-  // 处理导出设置变化
-  const handleSettingsChange = useCallback((changes: Partial<ExportSettingsState>) => {
-    setExportSettings(prev => ({ ...prev, ...changes }));
-  }, []);
-
-  // 处理视频导出
-  const handleExportVideo = useCallback(async () => {
-    setShowSettingsModal(false);
-
-    if (!editedSegments || editedSegments.length === 0) {
-      notify.warning('没有可用的脚本片段来剪辑视频');
-      return;
-    }
-
-    try {
-      const savePath = await save({
-        defaultPath: `剪辑_${new Date().toISOString().split('T')[0]}.${exportSettings.exportFormat}`,
-        filters: [{ name: '视频文件', extensions: [exportSettings.exportFormat] }],
-      });
-
-      if (!savePath) return;
-
-      setProcessing(true);
-      setProcessProgress(0);
-
-      const unlistenHandler: UnlistenFn = await listen<number>(
-        'cut_progress',
-        (event) => {
-          setProcessProgress(Math.round(event.payload * 100));
-        }
-      );
-
-      await tauri.cutVideo({
-        inputPath: videoPath,
-        outputPath: savePath,
-        segments: editedSegments.map(s => ({
-          start: s.startTime,
-          end: s.endTime,
-        })),
-      });
-
-      unlistenHandler();
-
-      if (onEditComplete) {
-        onEditComplete(savePath);
-      }
-
-      notify.success('视频剪辑完成');
-    } catch (error) {
-      logger.error('导出视频失败:', { error });
-      notify.error(error, '导出视频失败');
-    } finally {
-      setProcessing(false);
-    }
-  }, [editedSegments, exportSettings, videoPath, onEditComplete]);
-
-  // 保存片段
-  const handleSaveSegments = useCallback(() => {
-    if (onEditComplete) {
-      onEditComplete(editedSegments);
-    }
-    notify.success('片段时间已更新');
-  }, [editedSegments, onEditComplete]);
-
-  // 计算时间位置
-  const getTimeFromPosition = useCallback((clientX: number): number => {
-    const timelineEl = document.querySelector(`.${styles.timelineContainer}`);
-    if (!timelineEl) return 0;
-
-    const rect = timelineEl.getBoundingClientRect();
-    const relativeX = clientX - rect.left;
-    const percentage = Math.max(0, Math.min(1, relativeX / rect.width));
-
-    return percentage * duration;
-  }, [duration]);
-
-  // 拖拽时间线 ref，避免 useCallback 依赖
-  const timelineStateRef = useRef({ duration: 0 });
-  useEffect(() => {
-    timelineStateRef.current.duration = duration;
-  }, [duration]);
-
-  // 拖拽移动 — 从 ref 读取状态，避免闭包陷阱
-  const handleDragMove = useCallback((e: MouseEvent) => {
-    const { isDragging, dragSegmentId, dragType } = dragStateRef.current;
-    if (!isDragging || !dragSegmentId || !dragType) return;
-
-    const timelineTime = getTimeFromPosition(e.clientX);
-    const dur = timelineStateRef.current.duration;
-
-    setEditedSegments(prev =>
-      prev.map(segment => {
-        if (segment.id !== dragSegmentId) return segment;
-
-        const original = segment;
-        let newStart = original.startTime;
-        let newEnd = original.endTime;
-
-        switch (dragType) {
-          case 'move': {
-            const segmentDuration = original.endTime - original.startTime;
-            newStart = timelineTime;
-            newEnd = timelineTime + segmentDuration;
-
-            if (newStart < 0) {
-              newStart = 0;
-              newEnd = segmentDuration;
-            }
-            if (newEnd > globalVideoDuration) {
-              newEnd = globalVideoDuration;
-              newStart = newEnd - segmentDuration;
-            }
-            break;
-          }
-          case 'start': {
-            newStart = Math.min(timelineTime, original.endTime - 0.5);
-            newStart = Math.max(0, newStart);
-            break;
-          }
-          case 'end': {
-            newEnd = Math.max(timelineTime, original.startTime + 0.5);
-            newEnd = Math.min(dur, newEnd);
-            break;
-          }
-        }
-
-        return { ...segment, startTime: newStart, endTime: newEnd };
-      })
-    );
-  }, [getTimeFromPosition]);
-
-  // 结束拖拽 — 重置状态
-  const handleDragEnd = useCallback(() => {
-    setIsDragging(false);
-    setDragType(null);
-    setDragSegmentId(null);
-
-    document.removeEventListener('mousemove', handleDragMove);
-    document.removeEventListener('mouseup', handleDragEnd);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [handleDragMove]);
-
-  // 开始拖拽 — 稳定函数
-  const handleDragStart = useCallback((segmentId: string, type: 'move' | 'start' | 'end', e: React.MouseEvent) => {
-    e.stopPropagation();
-    setIsDragging(true);
-    setDragType(type);
-    setDragSegmentId(segmentId);
-
-    document.addEventListener('mousemove', handleDragMove);
-    document.addEventListener('mouseup', handleDragEnd);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [handleDragMove, handleDragEnd]);
+  const {
+    duration, isPlaying,
+    processing, processProgress,
+    selectedSegment, editedSegments,
+    exportSettings, settingsTab, showSettingsModal,
+    showPreviewModal, previewSegment, previewLoading, previewUrl,
+    setSettingsTab, setShowSettingsModal,
+    handleTimeUpdate, handleSegmentClick, handlePreviewSegment, handleClosePreview,
+    handleShowSettings, handleSettingsChange, handleExportVideo, handleSaveSegments,
+    handleDragStart,
+  } = useVideoEditorPage({ videoPath, segments, onEditComplete });
 
   return (
     <div className={styles.editorContainer}>

--- a/src/components/VideoEditor/hooks/useVideoEditorPage.reducer.ts
+++ b/src/components/VideoEditor/hooks/useVideoEditorPage.reducer.ts
@@ -1,0 +1,83 @@
+/**
+ * useVideoEditorPage reducer — 集中 15 useState 状态机
+ * 来源: refactor/video-editor-page-usereducer (v3.4 §A2 范式)
+ * 模式: 1 hook + 1 .reducer.ts + makeSetter<K> + Updater<T>
+ */
+import type { ScriptSegment } from '@/types';
+import type { ExportSettingsState } from '../ExportSettings';
+
+export interface VideoEditorPageState {
+  // player (3 — 保留丢弃 setter 兼容原 API)
+  currentTime: number;
+  duration: number;
+  isPlaying: boolean;
+  // processing (2)
+  processing: boolean;
+  processProgress: number;
+  // segment (2)
+  selectedSegment: ScriptSegment | null;
+  editedSegments: ScriptSegment[];
+  // export (3)
+  exportSettings: ExportSettingsState;
+  settingsTab: string;
+  showSettingsModal: boolean;
+  // preview (4)
+  showPreviewModal: boolean;
+  previewSegment: ScriptSegment | null;
+  previewLoading: boolean;
+  previewUrl: string;
+  // drag (3)
+  isDragging: boolean;
+  dragType: 'move' | 'start' | 'end' | null;
+  dragSegmentId: string | null;
+}
+
+export const initialVideoEditorPageState: VideoEditorPageState = {
+  currentTime: 0,
+  duration: 0,
+  isPlaying: false,
+  processing: false,
+  processProgress: 0,
+  selectedSegment: null,
+  editedSegments: [],
+  exportSettings: {
+    videoQuality: 'medium',
+    exportFormat: 'mp4',
+    transitionType: 'fade',
+    transitionDuration: 1,
+    audioVolume: 100,
+    useSubtitles: true,
+  },
+  settingsTab: 'general',
+  showSettingsModal: false,
+  showPreviewModal: false,
+  previewSegment: null,
+  previewLoading: false,
+  previewUrl: '',
+  isDragging: false,
+  dragType: null,
+  dragSegmentId: null,
+};
+
+export type Updater<T> = T | ((prev: T) => T);
+
+export type VideoEditorPageAction = {
+  type: 'update';
+  key: keyof VideoEditorPageState;
+  updater: Updater<unknown>;
+};
+
+export const videoEditorPageReducer = (
+  state: VideoEditorPageState,
+  action: VideoEditorPageAction,
+): VideoEditorPageState => {
+  if (action.type === 'update') {
+    const current = state[action.key];
+    const next =
+      typeof action.updater === 'function'
+        ? (action.updater as (prev: typeof current) => typeof current)(current)
+        : action.updater;
+    return { ...state, [action.key]: next };
+  }
+  return state;
+};

--- a/src/components/VideoEditor/hooks/useVideoEditorPage.ts
+++ b/src/components/VideoEditor/hooks/useVideoEditorPage.ts
@@ -1,0 +1,355 @@
+/**
+ * useVideoEditorPage hook — 15 useState 集中化入口
+ * 来源: refactor/video-editor-page-usereducer (v3.4 §A2 范式)
+ */
+import { useReducer, useMemo, useCallback, useRef, useEffect } from 'react';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { save } from '@tauri-apps/plugin-dialog';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import { ScriptSegment } from '@/types';
+import { notify } from '@/shared';
+import { logger } from '@/shared/utils/logging';
+import { tauri } from '@/core/tauri/TauriBridge';
+import type { ExportSettingsState } from '../ExportSettings';
+import styles from '@/components/VideoEditor/VideoEditor.module.less';
+import {
+  initialVideoEditorPageState,
+  videoEditorPageReducer,
+  type VideoEditorPageAction,
+  type VideoEditorPageState,
+  type Updater,
+} from './useVideoEditorPage.reducer';
+
+type Setter<K extends keyof VideoEditorPageState> = (
+  updater: Updater<VideoEditorPageState[K]>,
+) => void;
+type VideoEditorPageSetters = { [K in keyof VideoEditorPageState]: Setter<K> };
+
+const makeSetters = (
+  dispatch: React.Dispatch<VideoEditorPageAction>,
+): VideoEditorPageSetters => {
+  return Object.fromEntries(
+    (Object.keys(initialVideoEditorPageState) as (keyof VideoEditorPageState)[]).map(
+      (key) => [
+        key,
+        (updater: Updater<VideoEditorPageState[typeof key]>) =>
+          dispatch({ type: 'update', key, updater: updater as Updater<unknown> }),
+      ],
+    ),
+  ) as VideoEditorPageSetters;
+};
+
+interface UseVideoEditorPageArgs {
+  videoPath: string;
+  segments: ScriptSegment[];
+  onEditComplete?: (outputPath: string | ScriptSegment[]) => void;
+}
+
+// 全局变量存储视频时长，用于拖拽边界计算
+let globalVideoDuration = 0;
+
+export const useVideoEditorPage = ({
+  videoPath,
+  segments,
+  onEditComplete,
+}: UseVideoEditorPageArgs) => {
+  const [state, dispatch] = useReducer(videoEditorPageReducer, initialVideoEditorPageState);
+  const setters = useMemo(() => makeSetters(dispatch), []);
+  const {
+    currentTime, duration, isPlaying,
+    processing, processProgress,
+    selectedSegment, editedSegments,
+    exportSettings, settingsTab, showSettingsModal,
+    showPreviewModal, previewSegment, previewLoading, previewUrl,
+    isDragging, dragType, dragSegmentId,
+  } = state;
+
+  // 拖拽状态用 ref 存储，避免 useCallback 依赖导致重新绑定
+  const dragStateRef = useRef({
+    isDragging: false,
+    dragSegmentId: null as string | null,
+    dragType: null as 'move' | 'start' | 'end' | null,
+    duration: 0,
+  });
+
+  // 同步 dragStateRef
+  useEffect(() => {
+    dragStateRef.current = { isDragging, dragSegmentId, dragType, duration };
+  }, [isDragging, dragSegmentId, dragType, duration]);
+
+  // 同步传入的 segments
+  useEffect(() => {
+    setters.editedSegments(segments);
+  }, [segments, setters]);
+
+  // 更新全局视频时长
+  useEffect(() => {
+    globalVideoDuration = duration;
+  }, [duration]);
+
+  // 清理临时文件
+  useEffect(() => {
+    return () => {
+      if (previewUrl && previewUrl.includes('temp')) {
+        tauri.cleanTempFile(previewUrl).catch((e) =>
+          logger.error('clean_temp_file error:', { error: e }),
+        );
+      }
+    };
+  }, [previewUrl]);
+
+  // 处理时间更新
+  const handleTimeUpdate = useCallback(
+    (time: number) => {
+      setters.currentTime(time);
+    },
+    [setters],
+  );
+
+  // 点击片段
+  const handleSegmentClick = useCallback(
+    (segment: ScriptSegment) => {
+      setters.currentTime(segment.startTime);
+      setters.selectedSegment(segment);
+    },
+    [setters],
+  );
+
+  // 预览片段
+  const handlePreviewSegment = useCallback(
+    async (segment: ScriptSegment) => {
+      setters.previewLoading(true);
+      setters.previewSegment(segment);
+      setters.showPreviewModal(true);
+
+      try {
+        const tempPath = await tauri.generatePreview({
+          inputPath: videoPath,
+          segment: {
+            start: segment.startTime,
+            end: segment.endTime,
+          },
+        });
+
+        const fileUrl = convertFileSrc(tempPath);
+        setters.previewUrl(fileUrl);
+      } catch (error) {
+        logger.error('生成预览失败:', { error });
+        notify.error(error, '生成预览失败');
+      } finally {
+        setters.previewLoading(false);
+      }
+    },
+    [videoPath, setters],
+  );
+
+  // 关闭预览
+  const handleClosePreview = useCallback(() => {
+    setters.showPreviewModal(false);
+    setters.previewUrl('');
+    setters.previewSegment(null);
+  }, [setters]);
+
+  // 显示导出设置
+  const handleShowSettings = useCallback(() => {
+    setters.showSettingsModal(true);
+  }, [setters]);
+
+  // 处理导出设置变化
+  const handleSettingsChange = useCallback(
+    (changes: Partial<ExportSettingsState>) => {
+      setters.exportSettings((prev) => ({ ...prev, ...changes }));
+    },
+    [setters],
+  );
+
+  // 处理视频导出
+  const handleExportVideo = useCallback(async () => {
+    setters.showSettingsModal(false);
+
+    if (!editedSegments || editedSegments.length === 0) {
+      notify.warning('没有可用的脚本片段来剪辑视频');
+      return;
+    }
+
+    try {
+      const savePath = await save({
+        defaultPath: `剪辑_${new Date().toISOString().split('T')[0]}.${exportSettings.exportFormat}`,
+        filters: [{ name: '视频文件', extensions: [exportSettings.exportFormat] }],
+      });
+
+      if (!savePath) return;
+
+      setters.processing(true);
+      setters.processProgress(0);
+
+      const unlistenHandler: UnlistenFn = await listen<number>(
+        'cut_progress',
+        (event) => {
+          setters.processProgress(Math.round(event.payload * 100));
+        },
+      );
+
+      await tauri.cutVideo({
+        inputPath: videoPath,
+        outputPath: savePath,
+        segments: editedSegments.map((s) => ({
+          start: s.startTime,
+          end: s.endTime,
+        })),
+      });
+
+      unlistenHandler();
+
+      if (onEditComplete) {
+        onEditComplete(savePath);
+      }
+
+      notify.success('视频剪辑完成');
+    } catch (error) {
+      logger.error('导出视频失败:', { error });
+      notify.error(error, '导出视频失败');
+    } finally {
+      setters.processing(false);
+    }
+  }, [editedSegments, exportSettings, videoPath, onEditComplete, setters]);
+
+  // 保存片段
+  const handleSaveSegments = useCallback(() => {
+    if (onEditComplete) {
+      onEditComplete(editedSegments);
+    }
+    notify.success('片段时间已更新');
+  }, [editedSegments, onEditComplete]);
+
+  // 计算时间位置
+  const getTimeFromPosition = useCallback(
+    (clientX: number): number => {
+      const timelineEl = document.querySelector(`.${styles.timelineContainer}`);
+      if (!timelineEl) return 0;
+
+      const rect = timelineEl.getBoundingClientRect();
+      const relativeX = clientX - rect.left;
+      const percentage = Math.max(0, Math.min(1, relativeX / rect.width));
+
+      return percentage * duration;
+    },
+    [duration],
+  );
+
+  // 拖拽时间线 ref，避免 useCallback 依赖
+  const timelineStateRef = useRef({ duration: 0 });
+  useEffect(() => {
+    timelineStateRef.current.duration = duration;
+  }, [duration]);
+
+  // 拖拽移动 — 从 ref 读取状态，避免闭包陷阱
+  const handleDragMove = useCallback(
+    (e: MouseEvent) => {
+      const { isDragging, dragSegmentId, dragType } = dragStateRef.current;
+      if (!isDragging || !dragSegmentId || !dragType) return;
+
+      const timelineTime = getTimeFromPosition(e.clientX);
+      const dur = timelineStateRef.current.duration;
+
+      setters.editedSegments((prev) =>
+        prev.map((segment) => {
+          if (segment.id !== dragSegmentId) return segment;
+
+          const original = segment;
+          let newStart = original.startTime;
+          let newEnd = original.endTime;
+
+          switch (dragType) {
+            case 'move': {
+              const segmentDuration = original.endTime - original.startTime;
+              newStart = timelineTime;
+              newEnd = timelineTime + segmentDuration;
+
+              if (newStart < 0) {
+                newStart = 0;
+                newEnd = segmentDuration;
+              }
+              if (newEnd > globalVideoDuration) {
+                newEnd = globalVideoDuration;
+                newStart = newEnd - segmentDuration;
+              }
+              break;
+            }
+            case 'start': {
+              newStart = Math.min(timelineTime, original.endTime - 0.5);
+              newStart = Math.max(0, newStart);
+              break;
+            }
+            case 'end': {
+              newEnd = Math.max(timelineTime, original.startTime + 0.5);
+              newEnd = Math.min(dur, newEnd);
+              break;
+            }
+          }
+
+          return { ...segment, startTime: newStart, endTime: newEnd };
+        }),
+      );
+    },
+    [getTimeFromPosition, setters],
+  );
+
+  // 结束拖拽 — 重置状态
+  const handleDragEnd = useCallback(() => {
+    setters.isDragging(false);
+    setters.dragType(null);
+    setters.dragSegmentId(null);
+
+    document.removeEventListener('mousemove', handleDragMove);
+    document.removeEventListener('mouseup', handleDragEnd);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [handleDragMove, setters]);
+
+  // 开始拖拽 — 稳定函数
+  const handleDragStart = useCallback(
+    (segmentId: string, type: 'move' | 'start' | 'end', e: React.MouseEvent) => {
+      e.stopPropagation();
+      setters.isDragging(true);
+      setters.dragType(type);
+      setters.dragSegmentId(segmentId);
+
+      document.addEventListener('mousemove', handleDragMove);
+      document.addEventListener('mouseup', handleDragEnd);
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    },
+    [handleDragMove, handleDragEnd, setters],
+  );
+
+  return {
+    // state (read)
+    currentTime, duration, isPlaying,
+    processing, processProgress,
+    selectedSegment, editedSegments,
+    exportSettings, settingsTab, showSettingsModal,
+    showPreviewModal, previewSegment, previewLoading, previewUrl,
+    isDragging, dragType, dragSegmentId,
+    // setters (write, 1:1 兼容原 hook API)
+    setCurrentTime: setters.currentTime,
+    setDuration: setters.duration,
+    setIsPlaying: setters.isPlaying,
+    setSelectedSegment: setters.selectedSegment,
+    setEditedSegments: setters.editedSegments,
+    setSettingsTab: setters.settingsTab,
+    setShowSettingsModal: setters.showSettingsModal,
+    setShowPreviewModal: setters.showPreviewModal,
+    setPreviewSegment: setters.previewSegment,
+    setPreviewLoading: setters.previewLoading,
+    setPreviewUrl: setters.previewUrl,
+    setIsDragging: setters.isDragging,
+    // operations
+    handleTimeUpdate, handleSegmentClick, handlePreviewSegment, handleClosePreview,
+    handleShowSettings, handleSettingsChange, handleExportVideo, handleSaveSegments,
+    handleDragStart,
+  };
+};
+
+// Re-export globalVideoDuration setter for any external use
+export const setGlobalVideoDuration = (d: number) => {
+  globalVideoDuration = d;
+};


### PR DESCRIPTION
## 📦 概述
v3.4 §A2 范式 Phase 5: VideoEditor 主组件 15 useState → 1 useReducer

## 📊 改动量
| 文件 | 净 |
|---|---|
| src/components/VideoEditor/VideoEditor.tsx | **-260 行** ✅ (352 → 92) |
| src/components/VideoEditor/hooks/useVideoEditorPage.ts (新) | +355 行 |
| src/components/VideoEditor/hooks/useVideoEditorPage.reducer.ts (新) | +83 行 |
| **总计** | **+178** |

## 🔍 验证
- tsc --noEmit (rm .tsbuildinfo): 0 error
- eslint: 0 warning
- vitest: 271/271 pass
- vite build: 14.54s ✅

## 🎯 模式 (v3.4 §A2)
- 1 hook + 1 .reducer.ts
- 15 useState 集中化 (3 player + 2 processing + 2 segment + 3 export + 4 preview + 3 drag)
- `Object.fromEntries` 工厂模式 (避免显式 any)
- `Setter<K> = (updater: Updater<VideoEditorPageState[K]>) => void`

## 🛡️ 安全性
- 12 setter + 9 operations 1:1 兼容 (子组件 prop 全部不变)
- globalVideoDuration 全局变量保留 (drag 边界计算)
- dragStateRef/timelineStateRef refs 保留 (避免 useCallback 闭包陷阱)
- 3 个死代码 setter (currentTime/duration/isPlaying) 保留兼容
- React.memo 保留
- 0 冲突 (未碰 PR-A #26 / PR-B #27 / PR-D #28 / PR-E #29 / PR-F #31)