### PR TITLE
refactor(OriginalEditor): migrate 12 useState to useReducer (state machine)

### DIFF
--- a/src/components/ScriptEditor/OriginalEditor.tsx
+++ b/src/components/ScriptEditor/OriginalEditor.tsx
@@ -1,5 +1,4 @@
-import { logger } from '../../shared/utils/logging';
-import React, { useState, useEffect, useCallback, memo, useMemo } from 'react';
+import React, { memo } from 'react';
 import { Card, CardHeader, CardTitle } from '../ui/card';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '../ui/dropdown-menu';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '../ui/dialog';
@@ -11,14 +10,12 @@ import {
   Plus,
 } from 'lucide-react';
 import type { ScriptSegment } from '@/core/types';
-import type { VideoSegment } from '@/core/video';
-import { videoProcessor, formatDuration } from '@/core/video';
-import { convertFileSrc } from '@tauri-apps/api/core';
-import { notify } from '@/shared';
+import { formatDuration } from '@/core/video';
 import SegmentTable from './SegmentTable';
 import SegmentEditForm from './SegmentEditForm';
 import PreviewModal from './PreviewModal';
 import AIModal from './AIModal';
+import { useOriginalEditor } from './hooks/useOriginalEditor';
 import styles from '@/components/ScriptEditor/ScriptEditor.module.less';
 
 interface OriginalEditorProps {
@@ -28,165 +25,24 @@ interface OriginalEditorProps {
   onExport?: (format: string) => void;
 }
 
-interface SegmentFormValues {
-  start: number;
-  end: number;
-  type: string;
-  content: string;
-}
-
 const OriginalEditor: React.FC<OriginalEditorProps> = ({
   videoPath,
   initialSegments = [],
   onSave,
   onExport,
 }) => {
-  const [segments, setSegments] = useState<ScriptSegment[]>(initialSegments);
-  const [editingIndex, setEditingIndex] = useState<number | null>(null);
-  const [formValues, setFormValues] = useState<SegmentFormValues>({ start: 0, end: 30, type: 'narration', content: '' });
-  const [formError, setFormError] = useState<string>('');
-  const [previewVisible, setPreviewVisible] = useState(false);
-  const [previewSrc, setPreviewSrc] = useState('');
-  const [previewLoading, setPreviewLoading] = useState(false);
-  const [aiModalVisible, setAiModalVisible] = useState(false);
-  const [exportMenuOpen, setExportMenuOpen] = useState(false);
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
-  const [deleteTargetIndex, setDeleteTargetIndex] = useState<number | null>(null);
-  const [totalDuration, setTotalDuration] = useState(0);
-
-  useEffect(() => {
-    const duration = segments.reduce((sum, segment) => sum + (segment.endTime - segment.startTime), 0);
-    setTotalDuration(duration);
-  }, [segments]);
-
-  const setFieldValue = useCallback((field: keyof SegmentFormValues, value: string | number | null) => {
-    setFormValues(prev => ({ ...prev, [field]: value }));
-    setFormError('');
-  }, []);
-
-  const validateForm = useCallback((): boolean => {
-    const start = Number(formValues.start);
-    const end = Number(formValues.end);
-    if (isNaN(start) || isNaN(end)) { setFormError('请输入有效的时间值'); return false; }
-    if (end <= start) { setFormError('结束时间必须大于开始时间'); return false; }
-    if (!formValues.content.trim()) { setFormError('请输入内容'); return false; }
-    return true;
-  }, [formValues]);
-
-  // 添加新片段
-  const handleAddSegment = useCallback(() => {
-    const lastSegment = segments.length > 0 ? segments[segments.length - 1] : null;
-    const startTime = lastSegment ? lastSegment.endTime : 0;
-    const endTime = startTime + 30;
-    setFormValues({ start: startTime, end: endTime, type: 'narration', content: '' });
-    setFormError('');
-    setEditingIndex(segments.length);
-  }, [segments]);
-
-  // 编辑片段
-  const handleEditSegment = useCallback((index: number) => {
-    const segment = segments[index];
-    setFormValues({
-      start: segment.startTime,
-      end: segment.endTime,
-      type: segment.type || 'narration',
-      content: segment.content || '',
-    });
-    setFormError('');
-    setEditingIndex(index);
-  }, [segments]);
-
-  // 保存编辑片段
-  const handleSaveSegment = useCallback(() => {
-    if (!validateForm()) return;
-    const start = Number(formValues.start);
-    const end = Number(formValues.end);
-    const newSegments = [...segments];
-    const segment: ScriptSegment = {
-      id: `segment_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
-      startTime: start,
-      endTime: end,
-      type: formValues.type as ScriptSegment['type'],
-      content: formValues.content,
-    };
-    if (editingIndex !== null) {
-      if (editingIndex < segments.length) {
-        newSegments[editingIndex] = segment;
-      } else {
-        newSegments.push(segment);
-      }
-    }
-    setSegments(newSegments);
-    setEditingIndex(null);
-  }, [segments, editingIndex, formValues, validateForm]);
-
-  // 取消编辑
-  const handleCancelEdit = useCallback(() => {
-    setEditingIndex(null);
-    setFormError('');
-  }, []);
-
-  // 删除片段
-  const handleDeleteSegment = useCallback((index: number) => {
-    setDeleteTargetIndex(index);
-    setDeleteConfirmOpen(true);
-  }, []);
-
-  const confirmDelete = useCallback(() => {
-    if (deleteTargetIndex !== null) {
-      const newSegments = [...segments];
-      newSegments.splice(deleteTargetIndex, 1);
-      setSegments(newSegments);
-    }
-    setDeleteConfirmOpen(false);
-    setDeleteTargetIndex(null);
-  }, [deleteTargetIndex, segments]);
-
-  // 预览片段
-  const handlePreviewSegment = useCallback(async (index: number) => {
-    try {
-      setPreviewLoading(true);
-      const segment = segments[index];
-      const videoSegment: VideoSegment = { start: segment.startTime, end: segment.endTime };
-      const previewPath = await videoProcessor.preview(videoPath, videoSegment);
-      setPreviewSrc(convertFileSrc(previewPath));
-      setPreviewVisible(true);
-    } catch (error) {
-      logger.error('生成预览失败:', { error });
-      notify.error(error, '生成预览失败');
-    } finally {
-      setPreviewLoading(false);
-    }
-  }, [segments, videoPath]);
-
-  // 保存脚本
-  const handleSave = useCallback(() => {
-    onSave(segments);
-    notify.success('脚本已保存');
-  }, [onSave, segments]);
-
-  // AI 优化
-  const handleAIImprove = useCallback(async () => {
-    try {
-      notify.info('正在使用 AI 优化脚本...');
-      setAiModalVisible(false);
-      setTimeout(() => { notify.success('脚本优化完成'); }, 2000);
-    } catch (error) {
-      logger.error('AI 优化脚本失败:', { error });
-      notify.error(error, 'AI 优化脚本失败');
-    }
-  }, []);
-
-  const exportMenuItems = useMemo(() => ([
-    { key: 'txt', label: '文本文件 (.txt)' },
-    { key: 'srt', label: '字幕文件 (.srt)' },
-    { key: 'doc', label: 'Word文档 (.docx)' },
-  ]), []);
-
-  const handleExportClick = useCallback(({ key }: { key: string }) => {
-    onExport?.(String(key));
-    setExportMenuOpen(false);
-  }, [onExport]);
+  const {
+    segments, editingIndex, formValues, formError,
+    previewVisible, previewLoading, previewSrc,
+    aiModalVisible, exportMenuOpen, deleteConfirmOpen,
+    totalDuration,
+    setAiModalVisible, setExportMenuOpen, setDeleteConfirmOpen, setPreviewVisible,
+    setFieldValue,
+    handleAddSegment, handleEditSegment, handleSaveSegment, handleCancelEdit,
+    handleDeleteSegment, confirmDelete, handlePreviewSegment,
+    handleSave, handleAIImprove, handleExportClick,
+    exportMenuItems,
+  } = useOriginalEditor({ videoPath, initialSegments, onSave, onExport });
 
   return (
     <div className={styles.scriptEditor}>
@@ -247,7 +103,7 @@ const OriginalEditor: React.FC<OriginalEditorProps> = ({
           <SegmentEditForm
             formValues={formValues}
             formError={formError}
-            onFieldChange={setFieldValue as (field: keyof SegmentFormValues, value: string | number | null) => void}
+            onFieldChange={setFieldValue as (field: 'start' | 'end' | 'type' | 'content', value: string | number | null) => void}
             editingIndex={editingIndex}
             onSave={handleSaveSegment}
             onCancel={handleCancelEdit}

--- a/src/components/ScriptEditor/hooks/useOriginalEditor.reducer.ts
+++ b/src/components/ScriptEditor/hooks/useOriginalEditor.reducer.ts
@@ -1,0 +1,72 @@
+/**
+ * useOriginalEditor reducer — 集中 12 useState 状态机
+ * 来源: refactor/original-editor-usereducer (v3.4 §A2 范式)
+ * 模式: 1 hook + 1 .reducer.ts + makeSetter<K> + Updater<T>
+ */
+import type { ScriptSegment } from '@/core/types';
+
+export interface SegmentFormValues {
+  start: number;
+  end: number;
+  type: string;
+  content: string;
+}
+
+export interface OriginalEditorState {
+  // data
+  segments: ScriptSegment[];
+  editingIndex: number | null;
+  formValues: SegmentFormValues;
+  formError: string;
+  // preview
+  previewVisible: boolean;
+  previewSrc: string;
+  previewLoading: boolean;
+  // ui
+  aiModalVisible: boolean;
+  exportMenuOpen: boolean;
+  deleteConfirmOpen: boolean;
+  deleteTargetIndex: number | null;
+  // derived
+  totalDuration: number;
+}
+
+export const initialOriginalEditorState = (
+  initialSegments: ScriptSegment[],
+): OriginalEditorState => ({
+  segments: initialSegments,
+  editingIndex: null,
+  formValues: { start: 0, end: 30, type: 'narration', content: '' },
+  formError: '',
+  previewVisible: false,
+  previewSrc: '',
+  previewLoading: false,
+  aiModalVisible: false,
+  exportMenuOpen: false,
+  deleteConfirmOpen: false,
+  deleteTargetIndex: null,
+  totalDuration: 0,
+});
+
+export type Updater<T> = T | ((prev: T) => T);
+
+export type OriginalEditorAction = {
+  type: 'update';
+  key: keyof OriginalEditorState;
+  updater: Updater<unknown>;
+};
+
+export const originalEditorReducer = (
+  state: OriginalEditorState,
+  action: OriginalEditorAction,
+): OriginalEditorState => {
+  if (action.type === 'update') {
+    const current = state[action.key];
+    const next =
+      typeof action.updater === 'function'
+        ? (action.updater as (prev: typeof current) => typeof current)(current)
+        : action.updater;
+    return { ...state, [action.key]: next };
+  }
+  return state;
+};

--- a/src/components/ScriptEditor/hooks/useOriginalEditor.ts
+++ b/src/components/ScriptEditor/hooks/useOriginalEditor.ts
@@ -1,0 +1,256 @@
+/**
+ * useOriginalEditor hook — 12 useState 集中化入口
+ * 来源: refactor/original-editor-usereducer (v3.4 §A2 范式)
+ */
+import { useReducer, useMemo, useCallback, useEffect } from 'react';
+import { convertFileSrc } from '@tauri-apps/api/core';
+import type { ScriptSegment } from '@/core/types';
+import type { VideoSegment } from '@/core/video';
+import { videoProcessor } from '@/core/video';
+import { notify } from '@/shared';
+import { logger } from '@/shared/utils/logging';
+import {
+  initialOriginalEditorState,
+  originalEditorReducer,
+  type OriginalEditorAction,
+  type OriginalEditorState,
+  type SegmentFormValues,
+  type Updater,
+} from './useOriginalEditor.reducer';
+
+type Setter<K extends keyof OriginalEditorState> = (
+  updater: Updater<OriginalEditorState[K]>,
+) => void;
+type OriginalEditorSetters = { [K in keyof OriginalEditorState]: Setter<K> };
+
+const makeSetters = (
+  dispatch: React.Dispatch<OriginalEditorAction>,
+): OriginalEditorSetters => {
+  return Object.fromEntries(
+    (Object.keys(initialOriginalEditorState([])) as (keyof OriginalEditorState)[]).map(
+      (key) => [
+        key,
+        (updater: Updater<OriginalEditorState[typeof key]>) =>
+          dispatch({ type: 'update', key, updater: updater as Updater<unknown> }),
+      ],
+    ),
+  ) as OriginalEditorSetters;
+};
+
+interface UseOriginalEditorArgs {
+  videoPath: string;
+  initialSegments?: ScriptSegment[];
+  onSave: (segments: ScriptSegment[]) => void;
+  onExport?: (format: string) => void;
+}
+
+export const useOriginalEditor = ({
+  videoPath,
+  initialSegments = [],
+  onSave,
+  onExport,
+}: UseOriginalEditorArgs) => {
+  const [state, dispatch] = useReducer(
+    originalEditorReducer,
+    initialOriginalEditorState(initialSegments),
+  );
+  const setters = useMemo(() => makeSetters(dispatch), []);
+  const {
+    segments, editingIndex, formValues, formError,
+    previewVisible, previewSrc, previewLoading,
+    aiModalVisible, exportMenuOpen, deleteConfirmOpen, deleteTargetIndex,
+    totalDuration,
+  } = state;
+
+  useEffect(() => {
+    const duration = segments.reduce(
+      (sum, segment) => sum + (segment.endTime - segment.startTime),
+      0,
+    );
+    setters.totalDuration(duration);
+  }, [segments, setters]);
+
+  const setFieldValue = useCallback(
+    (field: keyof SegmentFormValues, value: string | number | null) => {
+      setters.formValues((prev) => ({ ...prev, [field]: value }));
+      setters.formError('');
+    },
+    [setters],
+  );
+
+  const validateForm = useCallback((): boolean => {
+    const start = Number(formValues.start);
+    const end = Number(formValues.end);
+    if (isNaN(start) || isNaN(end)) {
+      setters.formError('请输入有效的时间值');
+      return false;
+    }
+    if (end <= start) {
+      setters.formError('结束时间必须大于开始时间');
+      return false;
+    }
+    if (!formValues.content.trim()) {
+      setters.formError('请输入内容');
+      return false;
+    }
+    return true;
+  }, [formValues, setters]);
+
+  // 添加新片段
+  const handleAddSegment = useCallback(() => {
+    const lastSegment = segments.length > 0 ? segments[segments.length - 1] : null;
+    const startTime = lastSegment ? lastSegment.endTime : 0;
+    const endTime = startTime + 30;
+
+    setters.formValues({ start: startTime, end: endTime, type: 'narration', content: '' });
+    setters.formError('');
+    setters.editingIndex(segments.length);
+  }, [segments, setters]);
+
+  // 编辑片段
+  const handleEditSegment = useCallback(
+    (index: number) => {
+      const segment = segments[index];
+      setters.formValues({
+        start: segment.startTime,
+        end: segment.endTime,
+        type: segment.type || 'narration',
+        content: segment.content || '',
+      });
+      setters.formError('');
+      setters.editingIndex(index);
+    },
+    [segments, setters],
+  );
+
+  // 保存编辑片段
+  const handleSaveSegment = useCallback(() => {
+    if (!validateForm()) return;
+    const start = Number(formValues.start);
+    const end = Number(formValues.end);
+    const newSegments = [...segments];
+    const segment: ScriptSegment = {
+      id: `segment_${Date.now()}_${Math.random().toString(36).slice(2, 7)}`,
+      startTime: start,
+      endTime: end,
+      type: formValues.type as ScriptSegment['type'],
+      content: formValues.content,
+    };
+    if (editingIndex !== null) {
+      if (editingIndex < segments.length) {
+        newSegments[editingIndex] = segment;
+      } else {
+        newSegments.push(segment);
+      }
+    }
+    setters.segments(newSegments);
+    setters.editingIndex(null);
+  }, [segments, editingIndex, formValues, validateForm, setters]);
+
+  // 取消编辑
+  const handleCancelEdit = useCallback(() => {
+    setters.editingIndex(null);
+    setters.formError('');
+  }, [setters]);
+
+  // 删除片段
+  const handleDeleteSegment = useCallback(
+    (index: number) => {
+      setters.deleteTargetIndex(index);
+      setters.deleteConfirmOpen(true);
+    },
+    [setters],
+  );
+
+  const confirmDelete = useCallback(() => {
+    if (deleteTargetIndex !== null) {
+      const newSegments = [...segments];
+      newSegments.splice(deleteTargetIndex, 1);
+      setters.segments(newSegments);
+    }
+    setters.deleteConfirmOpen(false);
+    setters.deleteTargetIndex(null);
+  }, [deleteTargetIndex, segments, setters]);
+
+  // 预览片段
+  const handlePreviewSegment = useCallback(
+    async (index: number) => {
+      try {
+        setters.previewLoading(true);
+        const segment = segments[index];
+        const videoSegment: VideoSegment = { start: segment.startTime, end: segment.endTime };
+        const previewPath = await videoProcessor.preview(videoPath, videoSegment);
+        setters.previewSrc(convertFileSrc(previewPath));
+        setters.previewVisible(true);
+      } catch (error) {
+        logger.error('生成预览失败:', { error });
+        notify.error(error, '生成预览失败');
+      } finally {
+        setters.previewLoading(false);
+      }
+    },
+    [segments, videoPath, setters],
+  );
+
+  // 保存脚本
+  const handleSave = useCallback(() => {
+    onSave(segments);
+    notify.success('脚本已保存');
+  }, [onSave, segments]);
+
+  // AI 优化
+  const handleAIImprove = useCallback(async () => {
+    try {
+      notify.info('正在使用 AI 优化脚本...');
+      setters.aiModalVisible(false);
+      setTimeout(() => {
+        notify.success('脚本优化完成');
+      }, 2000);
+    } catch (error) {
+      logger.error('AI 优化脚本失败:', { error });
+      notify.error(error, 'AI 优化脚本失败');
+    }
+  }, [setters]);
+
+  const exportMenuItems = useMemo(
+    () => [
+      { key: 'txt', label: '文本文件 (.txt)' },
+      { key: 'srt', label: '字幕文件 (.srt)' },
+      { key: 'doc', label: 'Word文档 (.docx)' },
+    ],
+    [],
+  );
+
+  const handleExportClick = useCallback(
+    ({ key }: { key: string }) => {
+      onExport?.(String(key));
+      setters.exportMenuOpen(false);
+    },
+    [onExport, setters],
+  );
+
+  return {
+    // state (read)
+    segments, editingIndex, formValues, formError,
+    previewVisible, previewSrc, previewLoading,
+    aiModalVisible, exportMenuOpen, deleteConfirmOpen, deleteTargetIndex,
+    totalDuration,
+    // setters (write, 1:1 兼容)
+    setSegments: setters.segments,
+    setFormValues: setters.formValues,
+    setFormError: setters.formError,
+    setPreviewVisible: setters.previewVisible,
+    setPreviewSrc: setters.previewSrc,
+    setPreviewLoading: setters.previewLoading,
+    setAiModalVisible: setters.aiModalVisible,
+    setExportMenuOpen: setters.exportMenuOpen,
+    setDeleteConfirmOpen: setters.deleteConfirmOpen,
+    setDeleteTargetIndex: setters.deleteTargetIndex,
+    // operations
+    setFieldValue, validateForm,
+    handleAddSegment, handleEditSegment, handleSaveSegment, handleCancelEdit,
+    handleDeleteSegment, confirmDelete, handlePreviewSegment,
+    handleSave, handleAIImprove, handleExportClick,
+    exportMenuItems,
+  };
+};


### PR DESCRIPTION
## 📦 概述
v3.4 §A2 范式 Phase 7: OriginalEditor 12 useState → 1 useReducer

## 📊 改动量
| 文件 | 净 |
|---|---|
| OriginalEditor.tsx | **-144 行** ✅ (287 → ~143) |
| hooks/useOriginalEditor.ts (新) | +256 行 |
| hooks/useOriginalEditor.reducer.ts (新) | +72 行 |
| **总计** | **+184 行** |

## 🔍 验证
- tsc --noEmit (rm .tsbuildinfo): 0 error
- eslint: 0 warning
- vitest: 271/271 pass
- vite build: 15.07s ✅

## 🎯 模式 (v3.4 §A2)
- 1 hook + 1 .reducer.ts
- 12 useState 集中化 (4 data + 3 preview + 4 ui + 1 derived)
- `Object.fromEntries` 工厂模式 (避免显式 any)
- `Setter<K> = (updater: Updater<OriginalEditorState[K]>) => void`
- 主组件只读 state + 暴露 setter, 0 业务逻辑

## 🛡️ 安全性
- 10 setter 暴露 1:1 兼容 (子组件 prop 全部不变)
- setFieldValue 处理 formValues + formError 联动 (原子化)
- exportMenuItems useMemo 保留
- 4 个 Dialog/DropdownMenu 保留受控
- React.memo 保留