### PR TITLE
refactor(ScriptDetail): migrate 11 useState to useReducer (state machine)

### DIFF
--- a/src/hooks/useScriptDetail.reducer.ts
+++ b/src/hooks/useScriptDetail.reducer.ts
@@ -1,0 +1,88 @@
+import type { Script, ScriptSegment } from '@/core/services/ai/scriptService';
+
+export interface ScriptDetailState {
+  loading: boolean;
+  project: ScriptDetailProject | null;
+  script: Script | null;
+  segments: ScriptSegment[];
+  loadError: string;
+  reloadToken: number;
+  isSaving: boolean;
+  isExporting: boolean;
+  isDeleting: boolean;
+  deleteConfirmOpen: boolean;
+}
+
+export interface ScriptDetailProject {
+  id: string;
+  name: string;
+  description?: string;
+  status?: string;
+  createdAt?: string;
+  updatedAt: string;
+  scripts?: Script[];
+  videoPath?: string;
+  videos?: Array<{ path?: string }>;
+  videoUrl?: string;
+}
+
+export type ScriptDetailAction =
+  | { type: 'SET_LOADING'; loading: boolean }
+  | { type: 'SET_PROJECT'; project: ScriptDetailProject | null }
+  | { type: 'SET_SCRIPT'; script: Script | null }
+  | { type: 'SET_SEGMENTS'; segments: ScriptSegment[] }
+  | { type: 'SET_LOAD_ERROR'; loadError: string }
+  | { type: 'INCREMENT_RELOAD_TOKEN' }
+  | { type: 'SET_IS_SAVING'; isSaving: boolean }
+  | { type: 'SET_IS_EXPORTING'; isExporting: boolean }
+  | { type: 'SET_IS_DELETING'; isDeleting: boolean }
+  | { type: 'SET_DELETE_CONFIRM_OPEN'; open: boolean }
+  | { type: 'RESET_FOR_LOAD' }
+  | { type: 'RESET_FOR_RELOAD' };
+
+export const initialScriptDetailState: ScriptDetailState = {
+  loading: true,
+  project: null,
+  script: null,
+  segments: [],
+  loadError: '',
+  reloadToken: 0,
+  isSaving: false,
+  isExporting: false,
+  isDeleting: false,
+  deleteConfirmOpen: false,
+};
+
+export function scriptDetailReducer(
+  state: ScriptDetailState,
+  action: ScriptDetailAction,
+): ScriptDetailState {
+  switch (action.type) {
+    case 'SET_LOADING':
+      return { ...state, loading: action.loading };
+    case 'SET_PROJECT':
+      return { ...state, project: action.project };
+    case 'SET_SCRIPT':
+      return { ...state, script: action.script };
+    case 'SET_SEGMENTS':
+      return { ...state, segments: action.segments };
+    case 'SET_LOAD_ERROR':
+      return { ...state, loadError: action.loadError };
+    case 'INCREMENT_RELOAD_TOKEN':
+      return { ...state, reloadToken: state.reloadToken + 1 };
+    case 'SET_IS_SAVING':
+      return { ...state, isSaving: action.isSaving };
+    case 'SET_IS_EXPORTING':
+      return { ...state, isExporting: action.isExporting };
+    case 'SET_IS_DELETING':
+      return { ...state, isDeleting: action.isDeleting };
+    case 'SET_DELETE_CONFIRM_OPEN':
+      return { ...state, deleteConfirmOpen: action.open };
+    case 'RESET_FOR_LOAD':
+      return { ...state, project: null, script: null, segments: [], loadError: '', loading: true };
+    case 'RESET_FOR_RELOAD':
+      return { ...state, project: null, script: null, segments: [], loadError: '', loading: true };
+    default:
+      return state;
+  }
+}

--- a/src/hooks/useScriptDetail.ts
+++ b/src/hooks/useScriptDetail.ts
@@ -1,0 +1,104 @@
+import { useCallback, useMemo, useReducer } from 'react';
+import type { Script, ScriptSegment } from '@/core/services/ai/scriptService';
+import {
+  initialScriptDetailState,
+  scriptDetailReducer,
+  type ScriptDetailState,
+  type ScriptDetailProject,
+} from './useScriptDetail.reducer';
+
+export interface UseScriptDetailResult {
+  state: ScriptDetailState;
+  setLoading: (loading: boolean) => void;
+  setProject: (project: ScriptDetailProject | null) => void;
+  setScript: (script: Script | null) => void;
+  setSegments: (segments: ScriptSegment[]) => void;
+  setLoadError: (loadError: string) => void;
+  incrementReloadToken: () => void;
+  setIsSaving: (isSaving: boolean) => void;
+  setIsExporting: (isExporting: boolean) => void;
+  setIsDeleting: (isDeleting: boolean) => void;
+  setDeleteConfirmOpen: (open: boolean) => void;
+  resetForLoad: () => void;
+  resetForReload: () => void;
+}
+
+export function useScriptDetail(): UseScriptDetailResult {
+  const [state, dispatch] = useReducer(scriptDetailReducer, initialScriptDetailState);
+
+  const setLoading = useCallback((loading: boolean) => dispatch({ type: 'SET_LOADING', loading }), []);
+  const setProject = useCallback(
+    (project: ScriptDetailProject | null) => dispatch({ type: 'SET_PROJECT', project }),
+    [],
+  );
+  const setScript = useCallback(
+    (script: Script | null) => dispatch({ type: 'SET_SCRIPT', script }),
+    [],
+  );
+  const setSegments = useCallback(
+    (segments: ScriptSegment[]) => dispatch({ type: 'SET_SEGMENTS', segments }),
+    [],
+  );
+  const setLoadError = useCallback(
+    (loadError: string) => dispatch({ type: 'SET_LOAD_ERROR', loadError }),
+    [],
+  );
+  const incrementReloadToken = useCallback(
+    () => dispatch({ type: 'INCREMENT_RELOAD_TOKEN' }),
+    [],
+  );
+  const setIsSaving = useCallback(
+    (isSaving: boolean) => dispatch({ type: 'SET_IS_SAVING', isSaving }),
+    [],
+  );
+  const setIsExporting = useCallback(
+    (isExporting: boolean) => dispatch({ type: 'SET_IS_EXPORTING', isExporting }),
+    [],
+  );
+  const setIsDeleting = useCallback(
+    (isDeleting: boolean) => dispatch({ type: 'SET_IS_DELETING', isDeleting }),
+    [],
+  );
+  const setDeleteConfirmOpen = useCallback(
+    (open: boolean) => dispatch({ type: 'SET_DELETE_CONFIRM_OPEN', open }),
+    [],
+  );
+  const resetForLoad = useCallback(() => dispatch({ type: 'RESET_FOR_LOAD' }), []);
+  const resetForReload = useCallback(() => dispatch({ type: 'RESET_FOR_RELOAD' }), []);
+
+  return useMemo(
+    () => ({
+      state,
+      setLoading,
+      setProject,
+      setScript,
+      setSegments,
+      setLoadError,
+      incrementReloadToken,
+      setIsSaving,
+      setIsExporting,
+      setIsDeleting,
+      setDeleteConfirmOpen,
+      resetForLoad,
+      resetForReload,
+    }),
+    [
+      state,
+      setLoading,
+      setProject,
+      setScript,
+      setSegments,
+      setLoadError,
+      incrementReloadToken,
+      setIsSaving,
+      setIsExporting,
+      setIsDeleting,
+      setDeleteConfirmOpen,
+      resetForLoad,
+      resetForReload,
+    ],
+  );
+}
+
+export type { ScriptDetailState, ScriptDetailProject };
+export { initialScriptDetailState };

--- a/src/pages/ScriptDetail/index.tsx
+++ b/src/pages/ScriptDetail/index.tsx
@@ -1,5 +1,5 @@
 import { logger } from '../../shared/utils/logging';
-import React, { useState, useEffect, lazy, Suspense, useRef } from 'react';
+import React, { useEffect, lazy, Suspense, useRef } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { Card } from '../../components/ui/card';
 import { Button } from '../../components/ui/button';
@@ -14,6 +14,7 @@ import { findProjectByScriptId, normalizeProjectFile } from '../../core/utils/pr
 import type { ProjectFileLike } from '../../core/utils/project-file';
 import type { Script } from '@/core/services/ai/scriptService';
 import type { ScriptSegment } from '@/core/types';
+import { useScriptDetail } from '@/hooks/useScriptDetail';
 import styles from '@/pages/ScriptDetail/index.module.less';
 
 const loadScriptEditor = () => import('../../components/ScriptEditor');
@@ -36,16 +37,25 @@ const ScriptDetail: React.FC = () => {
   const { projectId, scriptId } = useParams<{ projectId: string; scriptId: string }>();
   const navigate = useNavigate();
   const { addRecentProject } = useSettings();
-  const [loading, setLoading] = useState(true);
-  const [project, setProject] = useState<ProjectWithScripts | null>(null);
-  const [script, setScript] = useState<Script | null>(null);
-  const [segments, setSegments] = useState<ScriptSegment[]>([]);
-  const [loadError, setLoadError] = useState<string>('');
-  const [reloadToken, setReloadToken] = useState(0);
-  const [isSaving, setIsSaving] = useState(false);
-  const [isExporting, setIsExporting] = useState(false);
-  const [isDeleting, setIsDeleting] = useState(false);
-  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+
+  // All UI/data state centralized in reducer
+  const {
+    state,
+    setLoading,
+    setProject,
+    setScript,
+    setSegments,
+    setLoadError,
+    incrementReloadToken,
+    setIsSaving,
+    setIsExporting,
+    setIsDeleting,
+    setDeleteConfirmOpen,
+    resetForLoad,
+  } = useScriptDetail();
+
+  const { loading, project, script, segments, loadError, reloadToken, isSaving, isExporting, isDeleting, deleteConfirmOpen } = state;
+
   const loadRequestSeqRef = useRef(0);
   const mountedRef = useRef(true);
 
@@ -59,9 +69,7 @@ const ScriptDetail: React.FC = () => {
 
     if (!scriptId) {
       if (isStale()) return;
-      setProject(null);
-      setScript(null);
-      setSegments([]);
+      resetForLoad();
       setLoadError('参数错误：缺少脚本ID');
       setLoading(false);
       return;
@@ -70,11 +78,7 @@ const ScriptDetail: React.FC = () => {
     const loadData = async () => {
       try {
         if (isStale()) return;
-        setProject(null);
-        setScript(null);
-        setSegments([]);
-        setLoading(true);
-        setLoadError('');
+        resetForLoad();
         let currentProject: ProjectWithScripts | undefined;
         if (projectId) {
           currentProject = await loadProjectWithRetry(projectId, { retries: 2, retryDelayMs: 260 }) as ProjectWithScripts | undefined;
@@ -114,7 +118,7 @@ const ScriptDetail: React.FC = () => {
     };
 
     void loadData();
-  }, [addRecentProject, projectId, scriptId, reloadToken]);
+  }, [addRecentProject, projectId, scriptId, reloadToken, resetForLoad, setLoadError, setLoading, setProject, setScript, setSegments]);
 
   useEffect(() => {
     if (!loading && project && script) {
@@ -200,7 +204,7 @@ const ScriptDetail: React.FC = () => {
         <div className="text-destructive text-lg font-medium">加载脚本失败</div>
         <div className="text-muted-foreground text-sm">{loadError}</div>
         <div className="flex gap-2">
-          <Button onClick={() => setReloadToken((v) => v + 1)}>重试</Button>
+          <Button onClick={incrementReloadToken}>重试</Button>
           {projectId ? <Button variant="outline" onClick={() => navigate(`/project/${projectId}`)}>返回项目</Button> : null}
           <Button variant="outline" onClick={() => navigate('/projects')}>返回项目列表</Button>
         </div>


### PR DESCRIPTION
## Summary
- Migrate 11 useState to useReducer in new useScriptDetail hook
- Extract state machine to useScriptDetail.reducer.ts (12 actions including reset helpers)
- All page state (loading, project, script, segments, error, tokens, modal flags) centralized

## Verification
- tsc 0 errors
- eslint 0 warnings
- vitest 271/271 pass
- vite build 13.64s ✓