### PR TITLE
refactor(SubtitleExtractor): migrate 10 useState to useReducer (state machine)

### DIFF
--- a/src/components/SubtitleExtractor/index.tsx
+++ b/src/components/SubtitleExtractor/index.tsx
@@ -8,7 +8,7 @@
  *
  * 设计风格：AI Cinema Studio Dark (#0C0D14)
  */
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 
 // ── Progress animation constants ──────────────────────────────────────────────
 const PROGRESS_UPDATE_INTERVAL_MS = 250;
@@ -39,17 +39,7 @@ import { useTimelineStore } from '@/store/timelineStore';
 import type { SubtitleEntry } from '@/core/types';
 import styles from './index.module.css';
 import { formatTime, formatSrtTime, MS_PER_SECOND } from '@/shared/utils/formatting';
-
-interface SubtitleSegment {
-  id: string;
-  startTime: number;
-  endTime: number;
-  start: string;
-  end: string;
-  text: string;
-  quality?: 'high' | 'medium' | 'low';
-}
-
+import { useSubtitleExtractor, type SubtitleSegment } from './useSubtitleExtractor';
 
 interface SubtitleExtractorProps {
   projectId: string;
@@ -64,15 +54,26 @@ const SubtitleExtractor: React.FC<SubtitleExtractorProps> = ({ projectId, videoU
   const setPreviewPlaying = useEditorStore(state => state.setPreviewPlaying);
   const videoRef = useRef<HTMLVideoElement>(null);
 
-  const [format, setFormat] = useState<'srt' | 'vtt' | 'txt'>('srt');
-  const [translate, setTranslate] = useState(false);
-  const [isExtracting, setIsExtracting] = useState(false);
-  const [progress, setProgress] = useState(0);
-  const [extractedSubtitles, setExtractedSubtitles] = useState<SubtitleSegment[]>([]);
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingText, setEditingText] = useState('');
-  const [activeSubId, setActiveSubId] = useState<string | null>(null);
-  const [videoDuration, setVideoDuration] = useState(0);
+  // All UI/data state centralized in reducer
+  const {
+    state,
+    setFormat,
+    setTranslate,
+    setIsExtracting,
+    setProgress,
+    incrementProgress,
+    setExtractedSubtitles,
+    updateSubtitleText,
+    setEditingId,
+    setEditingText,
+    setActiveSubId,
+    setVideoDuration,
+    startEdit,
+    cancelEdit,
+    resetForExtract,
+  } = useSubtitleExtractor();
+
+  const { format, translate, isExtracting, progress, extractedSubtitles, editingId, editingText, activeSubId, videoDuration } = state;
 
   const totalDuration = videoDuration > 0 ? videoDuration : 1;
   const playheadSec = playheadMs / MS_PER_SECOND;
@@ -90,7 +91,7 @@ const SubtitleExtractor: React.FC<SubtitleExtractorProps> = ({ projectId, videoU
     const video = videoRef.current;
     if (!video) return;
     setVideoDuration(video.duration);
-  }, []);
+  }, [setVideoDuration]);
 
   const togglePlay = useCallback(() => {
     const video = videoRef.current;
@@ -121,12 +122,9 @@ const SubtitleExtractor: React.FC<SubtitleExtractorProps> = ({ projectId, videoU
 
   const handleExtract = useCallback(async () => {
     if (!videoUrl) { notify.error(null, '未检测到视频源'); return; }
-    setIsExtracting(true);
-    setProgress(0);
-    setExtractedSubtitles([]);
-    setActiveSubId(null);
+    resetForExtract();
     try {
-      const interval = setInterval(() => { setProgress(prev => Math.min(prev + 8, PROGRESS_CAP)); }, PROGRESS_UPDATE_INTERVAL_MS);
+      const interval = setInterval(() => { incrementProgress(8, PROGRESS_CAP); }, PROGRESS_UPDATE_INTERVAL_MS);
       const result = await subtitleService.extractSubtitles(videoUrl, { language: 'zh-CN' });
       clearInterval(interval);
       setProgress(100);
@@ -140,16 +138,14 @@ const SubtitleExtractor: React.FC<SubtitleExtractorProps> = ({ projectId, videoU
       notify.success(`成功提取 ${subs.length} 条字幕`);
     } catch (error) { notify.error(error as Parameters<typeof notify.error>[0], '字幕提取失败'); }
     finally { setIsExtracting(false); }
-  }, [videoUrl, onExtracted]);
+  }, [videoUrl, onExtracted, resetForExtract, incrementProgress, setProgress, setExtractedSubtitles, setIsExtracting]);
 
-  const startEdit = useCallback((sub: SubtitleSegment) => { setEditingId(sub.id); setEditingText(sub.text); }, []);
   const saveEdit = useCallback(() => {
     if (!editingId) return;
-    setExtractedSubtitles(prev => prev.map(s => s.id === editingId ? { ...s, text: editingText } : s));
+    updateSubtitleText(editingId, editingText);
     setEditingId(null);
     notify.success('字幕已保存');
-  }, [editingId, editingText]);
-  const cancelEdit = useCallback(() => { setEditingId(null); setEditingText(''); }, []);
+  }, [editingId, editingText, updateSubtitleText, setEditingId]);
 
   const exportSubtitle = useCallback(() => {
     if (extractedSubtitles.length === 0) { notify.warning('无字幕可导出'); return; }

--- a/src/components/SubtitleExtractor/useSubtitleExtractor.reducer.ts
+++ b/src/components/SubtitleExtractor/useSubtitleExtractor.reducer.ts
@@ -1,0 +1,94 @@
+export type SubtitleFormat = 'srt' | 'vtt' | 'txt';
+
+export interface SubtitleSegment {
+  id: string;
+  startTime: number;
+  endTime: number;
+  start: string;
+  end: string;
+  text: string;
+  quality?: 'high' | 'medium' | 'low';
+}
+
+export interface SubtitleExtractorState {
+  format: SubtitleFormat;
+  translate: boolean;
+  isExtracting: boolean;
+  progress: number;
+  extractedSubtitles: SubtitleSegment[];
+  editingId: string | null;
+  editingText: string;
+  activeSubId: string | null;
+  videoDuration: number;
+}
+
+export type SubtitleExtractorAction =
+  | { type: 'SET_FORMAT'; format: SubtitleFormat }
+  | { type: 'SET_TRANSLATE'; translate: boolean }
+  | { type: 'SET_IS_EXTRACTING'; isExtracting: boolean }
+  | { type: 'SET_PROGRESS'; progress: number }
+  | { type: 'INCREMENT_PROGRESS'; delta: number; cap: number }
+  | { type: 'SET_EXTRACTED_SUBTITLES'; subtitles: SubtitleSegment[] }
+  | { type: 'UPDATE_SUBTITLE_TEXT'; id: string; text: string }
+  | { type: 'SET_EDITING_ID'; editingId: string | null }
+  | { type: 'SET_EDITING_TEXT'; editingText: string }
+  | { type: 'SET_ACTIVE_SUB_ID'; activeSubId: string | null }
+  | { type: 'SET_VIDEO_DURATION'; videoDuration: number }
+  | { type: 'START_EDIT'; sub: SubtitleSegment }
+  | { type: 'CANCEL_EDIT' }
+  | { type: 'RESET_FOR_EXTRACT' };
+
+export const initialSubtitleExtractorState: SubtitleExtractorState = {
+  format: 'srt',
+  translate: false,
+  isExtracting: false,
+  progress: 0,
+  extractedSubtitles: [],
+  editingId: null,
+  editingText: '',
+  activeSubId: null,
+  videoDuration: 0,
+};
+
+export function subtitleExtractorReducer(
+  state: SubtitleExtractorState,
+  action: SubtitleExtractorAction,
+): SubtitleExtractorState {
+  switch (action.type) {
+    case 'SET_FORMAT':
+      return { ...state, format: action.format };
+    case 'SET_TRANSLATE':
+      return { ...state, translate: action.translate };
+    case 'SET_IS_EXTRACTING':
+      return { ...state, isExtracting: action.isExtracting };
+    case 'SET_PROGRESS':
+      return { ...state, progress: action.progress };
+    case 'INCREMENT_PROGRESS':
+      return { ...state, progress: Math.min(state.progress + action.delta, action.cap) };
+    case 'SET_EXTRACTED_SUBTITLES':
+      return { ...state, extractedSubtitles: action.subtitles };
+    case 'UPDATE_SUBTITLE_TEXT':
+      return {
+        ...state,
+        extractedSubtitles: state.extractedSubtitles.map((s) =>
+          s.id === action.id ? { ...s, text: action.text } : s,
+        ),
+      };
+    case 'SET_EDITING_ID':
+      return { ...state, editingId: action.editingId };
+    case 'SET_EDITING_TEXT':
+      return { ...state, editingText: action.editingText };
+    case 'SET_ACTIVE_SUB_ID':
+      return { ...state, activeSubId: action.activeSubId };
+    case 'SET_VIDEO_DURATION':
+      return { ...state, videoDuration: action.videoDuration };
+    case 'START_EDIT':
+      return { ...state, editingId: action.sub.id, editingText: action.sub.text };
+    case 'CANCEL_EDIT':
+      return { ...state, editingId: null, editingText: '' };
+    case 'RESET_FOR_EXTRACT':
+      return { ...state, isExtracting: true, progress: 0, extractedSubtitles: [], activeSubId: null };
+    default:
+      return state;
+  }
+}

--- a/src/components/SubtitleExtractor/useSubtitleExtractor.ts
+++ b/src/components/SubtitleExtractor/useSubtitleExtractor.ts
@@ -1,0 +1,109 @@
+import { useCallback, useMemo, useReducer } from 'react';
+import {
+  initialSubtitleExtractorState,
+  subtitleExtractorReducer,
+  type SubtitleExtractorState,
+  type SubtitleFormat,
+  type SubtitleSegment,
+} from './useSubtitleExtractor.reducer';
+
+export interface UseSubtitleExtractorResult {
+  state: SubtitleExtractorState;
+  setFormat: (format: SubtitleFormat) => void;
+  setTranslate: (translate: boolean) => void;
+  setIsExtracting: (isExtracting: boolean) => void;
+  setProgress: (progress: number) => void;
+  incrementProgress: (delta: number, cap: number) => void;
+  setExtractedSubtitles: (subtitles: SubtitleSegment[]) => void;
+  updateSubtitleText: (id: string, text: string) => void;
+  setEditingId: (editingId: string | null) => void;
+  setEditingText: (editingText: string) => void;
+  setActiveSubId: (activeSubId: string | null) => void;
+  setVideoDuration: (videoDuration: number) => void;
+  startEdit: (sub: SubtitleSegment) => void;
+  cancelEdit: () => void;
+  resetForExtract: () => void;
+}
+
+export function useSubtitleExtractor(): UseSubtitleExtractorResult {
+  const [state, dispatch] = useReducer(subtitleExtractorReducer, initialSubtitleExtractorState);
+
+  const setFormat = useCallback((format: SubtitleFormat) => dispatch({ type: 'SET_FORMAT', format }), []);
+  const setTranslate = useCallback((translate: boolean) => dispatch({ type: 'SET_TRANSLATE', translate }), []);
+  const setIsExtracting = useCallback(
+    (isExtracting: boolean) => dispatch({ type: 'SET_IS_EXTRACTING', isExtracting }),
+    [],
+  );
+  const setProgress = useCallback((progress: number) => dispatch({ type: 'SET_PROGRESS', progress }), []);
+  const incrementProgress = useCallback(
+    (delta: number, cap: number) => dispatch({ type: 'INCREMENT_PROGRESS', delta, cap }),
+    [],
+  );
+  const setExtractedSubtitles = useCallback(
+    (subtitles: SubtitleSegment[]) => dispatch({ type: 'SET_EXTRACTED_SUBTITLES', subtitles }),
+    [],
+  );
+  const updateSubtitleText = useCallback(
+    (id: string, text: string) => dispatch({ type: 'UPDATE_SUBTITLE_TEXT', id, text }),
+    [],
+  );
+  const setEditingId = useCallback(
+    (editingId: string | null) => dispatch({ type: 'SET_EDITING_ID', editingId }),
+    [],
+  );
+  const setEditingText = useCallback(
+    (editingText: string) => dispatch({ type: 'SET_EDITING_TEXT', editingText }),
+    [],
+  );
+  const setActiveSubId = useCallback(
+    (activeSubId: string | null) => dispatch({ type: 'SET_ACTIVE_SUB_ID', activeSubId }),
+    [],
+  );
+  const setVideoDuration = useCallback(
+    (videoDuration: number) => dispatch({ type: 'SET_VIDEO_DURATION', videoDuration }),
+    [],
+  );
+  const startEdit = useCallback((sub: SubtitleSegment) => dispatch({ type: 'START_EDIT', sub }), []);
+  const cancelEdit = useCallback(() => dispatch({ type: 'CANCEL_EDIT' }), []);
+  const resetForExtract = useCallback(() => dispatch({ type: 'RESET_FOR_EXTRACT' }), []);
+
+  return useMemo(
+    () => ({
+      state,
+      setFormat,
+      setTranslate,
+      setIsExtracting,
+      setProgress,
+      incrementProgress,
+      setExtractedSubtitles,
+      updateSubtitleText,
+      setEditingId,
+      setEditingText,
+      setActiveSubId,
+      setVideoDuration,
+      startEdit,
+      cancelEdit,
+      resetForExtract,
+    }),
+    [
+      state,
+      setFormat,
+      setTranslate,
+      setIsExtracting,
+      setProgress,
+      incrementProgress,
+      setExtractedSubtitles,
+      updateSubtitleText,
+      setEditingId,
+      setEditingText,
+      setActiveSubId,
+      setVideoDuration,
+      startEdit,
+      cancelEdit,
+      resetForExtract,
+    ],
+  );
+}
+
+export type { SubtitleExtractorState, SubtitleFormat, SubtitleSegment };
+export { initialSubtitleExtractorState };


### PR DESCRIPTION
## Summary
- Migrate 10 useState to useReducer in new useSubtitleExtractor hook
- Extract state machine to useSubtitleExtractor.reducer.ts (15 actions including INCREMENT_PROGRESS, START_EDIT, RESET_FOR_EXTRACT)
- All component state centralized

## Verification
- tsc 0 errors
- eslint 0 warnings
- vitest 271/271 pass
- vite build 13.76s ✓