### PR TITLE
refactor(VideoPlayer): migrate 5 useState to useReducer (state machine)

### DIFF
--- a/src/components/VideoPlayer/VideoPlayer.reducer.ts
+++ b/src/components/VideoPlayer/VideoPlayer.reducer.ts
@@ -1,0 +1,56 @@
+/**
+ * VideoPlayer Reducer — 状态机化 useState 集合
+ *
+ * 5 个 useState → 1 个 reducer:
+ * - isPlaying: 播放/暂停状态
+ * - currentTime: 当前播放时间 (秒)
+ * - duration: 总时长 (秒)
+ * - volume: 音量 0-1
+ * - showVolumeSlider: 音量滑块悬停显示
+ *
+ * 设计点:
+ * - 直接 dispatch SET_* 模式 (同 AIVisualizer/VideoSelector 风格, 无 setter 包装工厂)
+ * - 5 个独立 action 即可: 5 个 useState 关联度低, 不需要复合 action
+ */
+export interface VideoPlayerState {
+  isPlaying: boolean;
+  currentTime: number;
+  duration: number;
+  volume: number;
+  showVolumeSlider: boolean;
+}
+
+export type VideoPlayerAction =
+  | { type: 'SET_IS_PLAYING'; isPlaying: boolean }
+  | { type: 'SET_CURRENT_TIME'; currentTime: number }
+  | { type: 'SET_DURATION'; duration: number }
+  | { type: 'SET_VOLUME'; volume: number }
+  | { type: 'SET_SHOW_VOLUME_SLIDER'; showVolumeSlider: boolean };
+
+export const initialVideoPlayerState: VideoPlayerState = {
+  isPlaying: false,
+  currentTime: 0,
+  duration: 0,
+  volume: 1,
+  showVolumeSlider: false,
+};
+
+export function videoPlayerReducer(
+  state: VideoPlayerState,
+  action: VideoPlayerAction,
+): VideoPlayerState {
+  switch (action.type) {
+    case 'SET_IS_PLAYING':
+      return { ...state, isPlaying: action.isPlaying };
+    case 'SET_CURRENT_TIME':
+      return { ...state, currentTime: action.currentTime };
+    case 'SET_DURATION':
+      return { ...state, duration: action.duration };
+    case 'SET_VOLUME':
+      return { ...state, volume: action.volume };
+    case 'SET_SHOW_VOLUME_SLIDER':
+      return { ...state, showVolumeSlider: action.showVolumeSlider };
+    default:
+      return state;
+  }
+}

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { useState, useRef, useEffect } from 'react';
+import { useReducer, useRef, useEffect } from 'react';
 import { Slider } from '../ui/slider';
 import { Button } from '../ui/button';
 import { formatTime } from '../../shared/utils/formatting';
@@ -9,6 +9,10 @@ import {
   Volume2,
   Maximize,
 } from 'lucide-react';
+import {
+  videoPlayerReducer,
+  initialVideoPlayerState,
+} from './VideoPlayer.reducer';
 import styles from '@/components/VideoPlayer/VideoPlayer.module.less';
 
 interface VideoPlayerProps {
@@ -21,6 +25,13 @@ interface VideoPlayerProps {
   onEnded?: () => void;
 }
 
+/**
+ * 视频播放器组件
+ *
+ * 状态机: 5 useState → 1 useReducer (state machine)
+ * - isPlaying/currentTime/duration/volume/showVolumeSlider
+ * - 事件驱动 setter (timeupdate/durationchange/ended/play/pause)
+ */
 function VideoPlayer({
   src,
   poster,
@@ -32,32 +43,29 @@ function VideoPlayer({
 }: VideoPlayerProps): React.ReactElement {
   const videoRef = useRef<HTMLVideoElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [isPlaying, setIsPlaying] = useState(false);
-  const [currentTime, setCurrentTime] = useState(0);
-  const [duration, setDuration] = useState(0);
-  const [volume, setVolume] = useState(1);
-  const [showVolumeSlider, setShowVolumeSlider] = useState(false);
+  const [state, dispatch] = useReducer(videoPlayerReducer, initialVideoPlayerState);
+  const { isPlaying, currentTime, duration, volume, showVolumeSlider } = state;
 
   useEffect(() => {
     const videoElement = videoRef.current;
     if (!videoElement) return;
 
     const handleTimeUpdate = () => {
-      setCurrentTime(videoElement.currentTime);
+      dispatch({ type: 'SET_CURRENT_TIME', currentTime: videoElement.currentTime });
       onTimeUpdate?.(videoElement.currentTime);
     };
 
     const handleDurationChange = () => {
-      setDuration(videoElement.duration);
+      dispatch({ type: 'SET_DURATION', duration: videoElement.duration });
     };
 
     const handleEnded = () => {
-      setIsPlaying(false);
+      dispatch({ type: 'SET_IS_PLAYING', isPlaying: false });
       onEnded?.();
     };
 
-    const handlePlay = () => setIsPlaying(true);
-    const handlePause = () => setIsPlaying(false);
+    const handlePlay = () => dispatch({ type: 'SET_IS_PLAYING', isPlaying: true });
+    const handlePause = () => dispatch({ type: 'SET_IS_PLAYING', isPlaying: false });
 
     videoElement.addEventListener('timeupdate', handleTimeUpdate);
     videoElement.addEventListener('durationchange', handleDurationChange);
@@ -125,12 +133,12 @@ function VideoPlayer({
         case 'ArrowUp':
           e.preventDefault();
           video.volume = Math.min(1, video.volume + 0.1);
-          setVolume(video.volume);
+          dispatch({ type: 'SET_VOLUME', volume: video.volume });
           break;
         case 'ArrowDown':
           e.preventDefault();
           video.volume = Math.max(0, video.volume - 0.1);
-          setVolume(video.volume);
+          dispatch({ type: 'SET_VOLUME', volume: video.volume });
           break;
         default:
           break;
@@ -156,7 +164,7 @@ function VideoPlayer({
     if (!videoElement) return;
     const val = Array.isArray(value) ? value[0] : value;
     videoElement.currentTime = val;
-    setCurrentTime(val);
+    dispatch({ type: 'SET_CURRENT_TIME', currentTime: val });
   };
 
   const handleVolumeChange = (value: number | readonly number[]) => {
@@ -164,7 +172,7 @@ function VideoPlayer({
     if (!videoElement) return;
     const val = Array.isArray(value) ? value[0] : value;
     videoElement.volume = val;
-    setVolume(val);
+    dispatch({ type: 'SET_VOLUME', volume: val });
   };
 
   const toggleFullscreen = () => {
@@ -218,8 +226,8 @@ function VideoPlayer({
           <div className={styles.rightControls}>
             <div
               className={styles.volumeControl}
-              onMouseEnter={() => setShowVolumeSlider(true)}
-              onMouseLeave={() => setShowVolumeSlider(false)}
+              onMouseEnter={() => dispatch({ type: 'SET_SHOW_VOLUME_SLIDER', showVolumeSlider: true })}
+              onMouseLeave={() => dispatch({ type: 'SET_SHOW_VOLUME_SLIDER', showVolumeSlider: false })}
             >
               <Button variant="ghost" className={styles.controlButton}>
                 <Volume2 />
@@ -247,4 +255,4 @@ function VideoPlayer({
   );
 }
 
-export default VideoPlayer; 
+export default VideoPlayer;


### PR DESCRIPTION
## 概述
VideoPlayer 组件 5 个 useState → 1 个 useReducer 状态机化

## 变更
- 新增 `src/components/VideoPlayer/VideoPlayer.reducer.ts` (56 行)
  - 5 个 SET action: SET_IS_PLAYING / SET_CURRENT_TIME / SET_DURATION / SET_VOLUME / SET_SHOW_VOLUME_SLIDER
- 主文件 `src/components/VideoPlayer/VideoPlayer.tsx` (249 → 258 行, +9 行)
  - `useReducer` 替换 5 个 `useState`
  - 所有 setter 调用方 → 直接 `dispatch({ type, ... })`
  - 视频事件回调 (timeupdate/durationchange/ended/play/pause) 全部走 dispatch
  - 键盘快捷键 (Arrow Up/Down) 音量调整走 dispatch
  - Slider onValueChange (currentTime/volume) 走 dispatch

## 设计
- 参考 AIVisualizer/VideoSelector 模式: 直接 dispatch, 不建 setter 包装工厂
- 5 个独立 SET action 即可, 字段关联度低, 不需要复合 action
- state destructure 在 render 顶部, 行为与原版 100% 一致

## 验证
- `tsc --noEmit`: 0 错
- `eslint src/components/VideoPlayer/`: 0 错 0 警告
- `npm run build`: ✓ built in 13.33s
- `vitest run`: 271/271 ✅

## 收益
- 状态集中化: 5 个独立 useState → 1 个 reducer 状态机
- 行为兼容: 0 调用方改动