### PR TITLE
refactor(WorkflowEditor): migrate 4 useState to useReducer (state machine)

### DIFF
--- a/src/components/ScriptEditor/WorkflowEditor.reducer.ts
+++ b/src/components/ScriptEditor/WorkflowEditor.reducer.ts
@@ -1,0 +1,59 @@
+/**
+ * WorkflowEditor Reducer — 状态机化 useState 集合
+ *
+ * 4 个 useState → 1 个 reducer:
+ * - activeTab: 当前 tab (content/segments/scenes)
+ * - editedContent: 编辑中内容 (form 字段)
+ * - editedTitle: 编辑中标题 (form 字段)
+ * - aiModalVisible: AI 优化模态框显示
+ *
+ * 设计点 (Pitfall 16/17 验证):
+ * - formValues 原子化: editedContent + editedTitle 一组 form 字段, 保持独立 setter
+ *   (不强制复合 setFieldValue, 因为 2 字段简单, 主组件 2 处 set 调用清楚)
+ * - Dialog 受控保留: aiModalVisible 必须暴露 setter 给 Dialog onOpenChange 用
+ * - SYNC_FROM_SCRIPT 复合 action: 替代原 useEffect 顶部 2 行 setEditedContent/setEditedTitle
+ */
+export interface WorkflowEditorState {
+  activeTab: string;
+  editedContent: string;
+  editedTitle: string;
+  aiModalVisible: boolean;
+}
+
+export type WorkflowEditorAction =
+  | { type: 'SET_ACTIVE_TAB'; activeTab: string }
+  | { type: 'SET_EDITED_CONTENT'; editedContent: string }
+  | { type: 'SET_EDITED_TITLE'; editedTitle: string }
+  | { type: 'SET_AI_MODAL_VISIBLE'; aiModalVisible: boolean }
+  | { type: 'SYNC_FROM_SCRIPT'; content: string; title: string };
+
+export const initialWorkflowEditorState: WorkflowEditorState = {
+  activeTab: 'content',
+  editedContent: '',
+  editedTitle: '',
+  aiModalVisible: false,
+};
+
+export function workflowEditorReducer(
+  state: WorkflowEditorState,
+  action: WorkflowEditorAction,
+): WorkflowEditorState {
+  switch (action.type) {
+    case 'SET_ACTIVE_TAB':
+      return { ...state, activeTab: action.activeTab };
+    case 'SET_EDITED_CONTENT':
+      return { ...state, editedContent: action.editedContent };
+    case 'SET_EDITED_TITLE':
+      return { ...state, editedTitle: action.editedTitle };
+    case 'SET_AI_MODAL_VISIBLE':
+      return { ...state, aiModalVisible: action.aiModalVisible };
+    case 'SYNC_FROM_SCRIPT':
+      return {
+        ...state,
+        editedContent: action.content,
+        editedTitle: action.title,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/components/ScriptEditor/WorkflowEditor.tsx
+++ b/src/components/ScriptEditor/WorkflowEditor.tsx
@@ -1,5 +1,5 @@
 import { logger } from '../../shared/utils/logging';
-import React, { useState, useEffect, useCallback, memo } from 'react';
+import React, { useReducer, useEffect, useCallback, memo } from 'react';
 import { Card } from '../ui/card';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
 import { Button } from '../ui/button';
@@ -14,6 +14,10 @@ import {
 import type { ScriptData, Scene, ScriptSegment } from '@/core/types';
 import { formatDuration } from '@/core/video';
 import { notify } from '@/shared';
+import {
+  workflowEditorReducer,
+  initialWorkflowEditorState,
+} from './WorkflowEditor.reducer';
 import styles from '@/components/ScriptEditor/ScriptEditor.module.less';
 
 interface WorkflowEditorProps {
@@ -23,28 +27,35 @@ interface WorkflowEditorProps {
   onScriptUpdate?: (script: ScriptData) => void;
 }
 
+/**
+ * 脚本工作流编辑器
+ *
+ * 状态机: 4 useState → 1 useReducer (state machine)
+ * - form 字段 (editedContent/editedTitle) + tab + Dialog 状态
+ */
 const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   script,
   scenes,
   onSave,
   onScriptUpdate,
 }) => {
-  const [activeTab, setActiveTab] = useState('content');
-  const [editedContent, setEditedContent] = useState('');
-  const [editedTitle, setEditedTitle] = useState('');
-  const [aiModalVisible, setAiModalVisible] = useState(false);
+  const [state, dispatch] = useReducer(workflowEditorReducer, initialWorkflowEditorState);
+  const { activeTab, editedContent, editedTitle, aiModalVisible } = state;
 
   useEffect(() => {
-    setEditedContent(script.content || '');
-    setEditedTitle(script.title || '');
+    dispatch({
+      type: 'SYNC_FROM_SCRIPT',
+      content: script.content || '',
+      title: script.title || '',
+    });
   }, [script]);
 
   const handleContentChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setEditedContent(e.target.value);
+    dispatch({ type: 'SET_EDITED_CONTENT', editedContent: e.target.value });
   }, []);
 
   const handleTitleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
-    setEditedTitle(e.target.value);
+    dispatch({ type: 'SET_EDITED_TITLE', editedTitle: e.target.value });
   }, []);
 
   const handleSave = useCallback(() => {
@@ -62,7 +73,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
   const handleAIImprove = useCallback(async () => {
     try {
       notify.info('正在使用 AI 优化脚本...');
-      setAiModalVisible(false);
+      dispatch({ type: 'SET_AI_MODAL_VISIBLE', aiModalVisible: false });
       setTimeout(() => {
         notify.success('脚本优化完成');
       }, 2000);
@@ -78,7 +89,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-base font-semibold">脚本编辑</h3>
           <div className="flex gap-2">
-            <Button variant="outline"  onClick={() => setAiModalVisible(true)}>
+            <Button variant="outline"  onClick={() => dispatch({ type: 'SET_AI_MODAL_VISIBLE', aiModalVisible: true })}>
               <Edit size={14} className="mr-1" />
               AI优化
             </Button>
@@ -89,7 +100,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           </div>
         </div>
 
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
+        <Tabs value={activeTab} onValueChange={(v) => dispatch({ type: 'SET_ACTIVE_TAB', activeTab: v })}>
           <TabsList>
             <TabsTrigger value="content">脚本内容</TabsTrigger>
             <TabsTrigger value="segments">片段列表</TabsTrigger>
@@ -106,7 +117,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
                   value={editedTitle}
                   onChange={handleTitleChange}
                   placeholder="输入脚本标题"
-                  
+
                 />
               </div>
               <div className={styles.contentInput}>
@@ -166,7 +177,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
       </Card>
 
       {/* AI 优化模态框 */}
-      <Dialog open={aiModalVisible} onOpenChange={(open) => !open && setAiModalVisible(false)}>
+      <Dialog open={aiModalVisible} onOpenChange={(open) => !open && dispatch({ type: 'SET_AI_MODAL_VISIBLE', aiModalVisible: false })}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>AI 优化脚本</DialogTitle>
@@ -174,7 +185,7 @@ const WorkflowEditor: React.FC<WorkflowEditorProps> = ({
           <p className="text-sm text-muted-foreground">使用 AI 优化脚本将会根据视频内容和当前脚本，生成更加专业的表达和结构。</p>
           <p className="text-sm text-muted-foreground">点击确定开始优化。</p>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setAiModalVisible(false)}>取消</Button>
+            <Button variant="outline" onClick={() => dispatch({ type: 'SET_AI_MODAL_VISIBLE', aiModalVisible: false })}>取消</Button>
             <Button className="bg-[--accent-primary] hover:bg-[--accent-primary-hover] text-white" onClick={handleAIImprove}>确定</Button>
           </DialogFooter>
         </DialogContent>


### PR DESCRIPTION
## 概述
WorkflowEditor 组件 4 个 useState → 1 个 useReducer 状态机化

## 变更
- 新增 `src/components/ScriptEditor/WorkflowEditor.reducer.ts` (59 行)
  - 4 个 SET action + SYNC_FROM_SCRIPT 复合 action (Pitfall 16/17/23 模式)
- 主文件 `src/components/ScriptEditor/WorkflowEditor.tsx` (186 → 197 行, +11 行)
  - `useReducer` 替换 4 个 `useState`
  - 所有 setter 调用方 → 直接 `dispatch({ type, ... })`
  - useEffect 顶部 2 行 setter → 1 dispatch SYNC_FROM_SCRIPT
  - Dialog 受控保留 (aiModalVisible setter 给 onOpenChange 用)

## 设计
- 参考 AIVisualizer/VideoSelector 模式: 直接 dispatch, 不建 setter 包装工厂
- SYNC_FROM_SCRIPT 复合 action: 替代原 useEffect 顶部 2 行 setter (Pitfall 23 复合 action 模式)
- form 字段 (editedContent/editedTitle) 保持独立 setter, 2 字段简单不强制复合
- Dialog 受控保留 (Pitfall 17): aiModalVisible setter 仍暴露给 onOpenChange

## 验证
- `tsc --noEmit`: 0 错
- `eslint src/components/ScriptEditor/`: 0 错 0 警告
- `npm run build`: ✓ built in 12.38s
- `vitest run`: 271/271 ✅

## 收益
- 状态集中化: 4 个独立 useState → 1 个 reducer 状态机
- 复合 action: useEffect 同步 2 setter → 1 dispatch SYNC_FROM_SCRIPT
- 行为兼容: 0 调用方改动