### PR TITLE
refactor(VideoUpload): migrate 5 useState to useReducer (state machine)

### DIFF
--- a/src/components/StoryFab/workspace/VideoUpload.reducer.ts
+++ b/src/components/StoryFab/workspace/VideoUpload.reducer.ts
@@ -1,0 +1,90 @@
+/**
+ * VideoUpload Reducer — 状态机化 useState 集合
+ *
+ * 5 个 useState → 1 个 reducer:
+ * - uploading: 是否上传中
+ * - uploadProgress: 上传进度 0-100
+ * - dragActive: 拖拽 UI 高亮
+ * - uploadStatus: 状态机 'idle' | 'uploading' | 'paused' | 'completed'
+ * - currentFile: 当前上传文件引用
+ *
+ * 设计点 (Pitfall 23 复合 action 模式):
+ * - START_UPLOAD 复合 action: 替代 handleUpload 顶部 5 行 setter (uploading + uploadProgress 0 + uploadStatus 'uploading' + currentFile + 后续状态)
+ * - HANDLE_DELETE 复合 action: 替代 handleDelete 4 行 setter (uploadProgress 0 + uploadStatus 'idle' + currentFile null)
+ * - TOGGLE_PAUSE 复合 action: handlePauseResume 切换 'uploading' ↔ 'paused'
+ */
+export type UploadStatus = 'idle' | 'uploading' | 'paused' | 'completed';
+
+export interface VideoUploadState {
+  uploading: boolean;
+  uploadProgress: number;
+  dragActive: boolean;
+  uploadStatus: UploadStatus;
+  currentFile: File | null;
+}
+
+export type VideoUploadAction =
+  | { type: 'SET_UPLOADING'; uploading: boolean }
+  | { type: 'SET_UPLOAD_PROGRESS'; uploadProgress: number }
+  | { type: 'SET_DRAG_ACTIVE'; dragActive: boolean }
+  | { type: 'SET_UPLOAD_STATUS'; uploadStatus: UploadStatus }
+  | { type: 'SET_CURRENT_FILE'; currentFile: File | null }
+  | { type: 'START_UPLOAD'; file: File }
+  | { type: 'TOGGLE_PAUSE' }
+  | { type: 'COMPLETE_UPLOAD' }
+  | { type: 'RESET' };
+
+export const initialVideoUploadState: VideoUploadState = {
+  uploading: false,
+  uploadProgress: 0,
+  dragActive: false,
+  uploadStatus: 'idle',
+  currentFile: null,
+};
+
+export function videoUploadReducer(
+  state: VideoUploadState,
+  action: VideoUploadAction,
+): VideoUploadState {
+  switch (action.type) {
+    case 'SET_UPLOADING':
+      return { ...state, uploading: action.uploading };
+    case 'SET_UPLOAD_PROGRESS':
+      return { ...state, uploadProgress: action.uploadProgress };
+    case 'SET_DRAG_ACTIVE':
+      return { ...state, dragActive: action.dragActive };
+    case 'SET_UPLOAD_STATUS':
+      return { ...state, uploadStatus: action.uploadStatus };
+    case 'SET_CURRENT_FILE':
+      return { ...state, currentFile: action.currentFile };
+    case 'START_UPLOAD':
+      return {
+        ...state,
+        uploading: true,
+        uploadProgress: 0,
+        uploadStatus: 'uploading',
+        currentFile: action.file,
+      };
+    case 'TOGGLE_PAUSE':
+      return {
+        ...state,
+        uploadStatus: state.uploadStatus === 'uploading' ? 'paused' : 'uploading',
+      };
+    case 'COMPLETE_UPLOAD':
+      return {
+        ...state,
+        uploadProgress: 100,
+        uploadStatus: 'completed',
+      };
+    case 'RESET':
+      return {
+        ...state,
+        uploading: false,
+        uploadProgress: 0,
+        uploadStatus: 'idle',
+        currentFile: null,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/components/StoryFab/workspace/VideoUpload.tsx
+++ b/src/components/StoryFab/workspace/VideoUpload.tsx
@@ -8,12 +8,16 @@
  * - 上传配置已提取到 config/videoUploadConfig.ts
  * - 本文件仅包含上传组件逻辑和 UI
  */
-import React, { useState, useCallback, useRef, useEffect, memo } from 'react';
+import React, { useReducer, useCallback, useRef, useEffect, memo } from 'react';
 import { useStoryFab } from '../context';
 import { logger } from '../../../shared/utils/logging';
 import { formatDuration, formatFileSize, notify } from '@/shared';
 import { MAX_FILE_SIZE } from '@/shared/constants';
 import type { VideoInfo } from '@/core/types';
+import {
+  videoUploadReducer,
+  initialVideoUploadState,
+} from './VideoUpload.reducer';
 import styles from './VideoUpload.module.css';
 
 import {
@@ -31,12 +35,14 @@ interface VideoUploadProps {
 
 const VideoUpload: React.FC<VideoUploadProps> = memo(({ onNext }) => {
   const { state, setVideo, goToNextStep } = useStoryFab();
-  const [uploading, setUploading] = useState(false);
-  const [uploadProgress, setUploadProgress] = useState(0);
-  const [dragActive, setDragActive] = useState(false);
-  const [uploadStatus, setUploadStatus] = useState<'idle' | 'uploading' | 'paused' | 'completed'>('idle');
-  const [currentFile, setCurrentFile] = useState<File | null>(null);
+  const [local, dispatch] = useReducer(videoUploadReducer, initialVideoUploadState);
+  const { uploading, uploadProgress, dragActive, uploadStatus, currentFile } = local;
+  // ref 镜像 uploadStatus — async setInterval 回调需要读到最新值
+  // ref 保持宽 string 类型, 兼容 setInterval 内对 'cancelled' | 'error' 的死代码判等
   const uploadStatusRef = useRef<string>('idle');
+  useEffect(() => {
+    uploadStatusRef.current = uploadStatus;
+  }, [uploadStatus]);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const pauseIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -80,11 +86,7 @@ const VideoUpload: React.FC<VideoUploadProps> = memo(({ onNext }) => {
       return;
     }
 
-    setUploading(true);
-    setUploadProgress(0);
-    setUploadStatus('uploading');
-    uploadStatusRef.current = 'uploading';
-    setCurrentFile(file);
+    dispatch({ type: 'START_UPLOAD', file });
 
     const uploadId = `upload_${Date.now()}`;
     chunkStore.clear(uploadId);
@@ -126,7 +128,7 @@ const VideoUpload: React.FC<VideoUploadProps> = memo(({ onNext }) => {
         chunkStore.addChunk(uploadId, chunk, i);
 
         const progress = Math.min(((i + 1) / totalChunks) * 100, 100);
-        setUploadProgress(progress);
+        dispatch({ type: 'SET_UPLOAD_PROGRESS', uploadProgress: progress });
 
         await new Promise(r => setTimeout(r, UPLOAD_DELAY_MIN_MS + Math.random() * UPLOAD_DELAY_RANGE_MS));
       }
@@ -160,8 +162,7 @@ const VideoUpload: React.FC<VideoUploadProps> = memo(({ onNext }) => {
         video.src = URL.createObjectURL(file);
       });
 
-      setUploadProgress(100);
-      setUploadStatus('completed');
+      dispatch({ type: 'COMPLETE_UPLOAD' });
       setVideo(videoInfo);
       notify.success('视频上传成功');
 
@@ -174,47 +175,41 @@ const VideoUpload: React.FC<VideoUploadProps> = memo(({ onNext }) => {
       notify.error(error, '视频处理失败，请重试');
       logger.error('VideoUpload error:', { error });
     } finally {
-      setUploading(false);
+      dispatch({ type: 'SET_UPLOADING', uploading: false });
     }
   }, [setVideo]);
 
   // 暂停/继续
   const handlePauseResume = () => {
     if (uploadStatus === 'uploading') {
-      setUploadStatus('paused');
-      uploadStatusRef.current = 'paused';
       notify.info('上传已暂停');
     } else if (uploadStatus === 'paused') {
-      setUploadStatus('uploading');
-      uploadStatusRef.current = 'uploading';
       notify.info('继续上传中...');
     }
+    dispatch({ type: 'TOGGLE_PAUSE' });
   };
 
   // 删除视频
   const handleDelete = () => {
     setVideo(null);
-    setUploadProgress(0);
-    setUploadStatus('idle');
-    uploadStatusRef.current = 'idle';
-    setCurrentFile(null);
+    dispatch({ type: 'RESET' });
     chunkStore.clear('current');
   };
 
   // 拖拽事件
   const handleDragOver = (e: React.DragEvent) => {
     e.preventDefault();
-    setDragActive(true);
+    dispatch({ type: 'SET_DRAG_ACTIVE', dragActive: true });
   };
 
   const handleDragLeave = (e: React.DragEvent) => {
     e.preventDefault();
-    setDragActive(false);
+    dispatch({ type: 'SET_DRAG_ACTIVE', dragActive: false });
   };
 
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault();
-    setDragActive(false);
+    dispatch({ type: 'SET_DRAG_ACTIVE', dragActive: false });
     const files = e.dataTransfer.files;
     if (files.length > 0) {
       handleUpload(files[0]);


### PR DESCRIPTION
## 概述
VideoUpload 组件 5 个 useState → 1 个 useReducer 状态机化

## 变更
- 新增 `src/components/StoryFab/workspace/VideoUpload.reducer.ts` (90 行)
  - 5 个 SET action + 4 个复合 action: START_UPLOAD / TOGGLE_PAUSE / COMPLETE_UPLOAD / RESET
- 主文件 `src/components/StoryFab/workspace/VideoUpload.tsx` (463 → 458 行, -5 行)
  - `useReducer` 替换 5 个 `useState`
  - 所有 setter 调用方 → 直接 `dispatch({ type, ... })`

## 设计
- 参考 AIVisualizer/VideoSelector/VideoPlayer/WorkflowEditor 模式: 直接 dispatch, 不建 setter 包装工厂
- 4 复合 action (Pitfall 23 模式): 业务语义化上传生命周期
  - **START_UPLOAD**: 替代原 handleUpload 顶部 5 行 setter (uploading + progress 0 + status 'uploading' + currentFile + ref 同步)
  - **TOGGLE_PAUSE**: handlePauseResume 切换 'uploading' ↔ 'paused' 业务逻辑移到 reducer
  - **COMPLETE_UPLOAD**: 替代 setUploadProgress(100) + setUploadStatus('completed') 2 行
  - **RESET**: 替代 handleDelete 4 行 setter (progress 0 + status 'idle' + currentFile null + ref 同步)
- uploadStatusRef 保持宽 string 类型, 兼容 setInterval 内对 'cancelled' | 'error' 的死代码判等 (Pitfall 18 Type 边界)
- ref 同步用 useEffect 显式声明, 避免在函数体内直接赋值触 lint warning

## 验证
- `tsc --noEmit`: 0 错
- `eslint src/components/StoryFab/workspace/VideoUpload.tsx`: 0 错 0 警告
- `npm run build`: ✓ built in 12.51s
- `vitest run`: 271/271 ✅

## 收益
- 状态集中化: 5 个独立 useState → 1 个 reducer 状态机
- 业务语义化: 4 复合 action 描述完整上传生命周期 (START/PAUSE/COMPLETE/RESET)
- 主文件 -5 行 (净减, 因为 setter 包装代码减少, 抵消 reducer import + JSDoc 开销)
- 行为兼容: 0 调用方改动