### PR TITLE
refactor(CommentaryPanel): migrate 5 useState to useReducer (state machine)

### DIFF
--- a/src/components/CommentaryPanel/CommentaryPanel.reducer.ts
+++ b/src/components/CommentaryPanel/CommentaryPanel.reducer.ts
@@ -1,0 +1,53 @@
+/**
+ * CommentaryPanel Reducer — 状态机化 useState 集合
+ *
+ * 5 个 useState → 1 个 reducer:
+ * - activeTab: 当前 tab (script/style/voice/timeline)
+ * - planConfirmOpen: 计划确认弹窗
+ * - reviseOpen: 修订弹窗 (原代码 _reviseOpen 死代码, 保留 state 字段以备未来使用, Pitfall 12)
+ * - apiKey: 用户 API key
+ * - selectedStyle: 当前选中风格预设
+ */
+import type { ScriptStylePreset } from '@/core/services/commentary';
+
+export type CommentaryTab = 'script' | 'style' | 'voice' | 'timeline';
+
+export interface CommentaryPanelState {
+  activeTab: CommentaryTab;
+  planConfirmOpen: boolean;
+  reviseOpen: boolean;
+  apiKey: string;
+  selectedStyle: ScriptStylePreset;
+}
+
+export type CommentaryPanelAction =
+  | { type: 'SET_ACTIVE_TAB'; activeTab: CommentaryTab }
+  | { type: 'SET_PLAN_CONFIRM_OPEN'; planConfirmOpen: boolean }
+  | { type: 'SET_API_KEY'; apiKey: string }
+  | { type: 'SET_SELECTED_STYLE'; selectedStyle: ScriptStylePreset };
+
+export const initialCommentaryPanelState: CommentaryPanelState = {
+  activeTab: 'script',
+  planConfirmOpen: false,
+  reviseOpen: false,
+  apiKey: '',
+  selectedStyle: 'conversational',
+};
+
+export function commentaryPanelReducer(
+  state: CommentaryPanelState,
+  action: CommentaryPanelAction,
+): CommentaryPanelState {
+  switch (action.type) {
+    case 'SET_ACTIVE_TAB':
+      return { ...state, activeTab: action.activeTab };
+    case 'SET_PLAN_CONFIRM_OPEN':
+      return { ...state, planConfirmOpen: action.planConfirmOpen };
+    case 'SET_API_KEY':
+      return { ...state, apiKey: action.apiKey };
+    case 'SET_SELECTED_STYLE':
+      return { ...state, selectedStyle: action.selectedStyle };
+    default:
+      return state;
+  }
+}

--- a/src/components/CommentaryPanel/CommentaryPanel.tsx
+++ b/src/components/CommentaryPanel/CommentaryPanel.tsx
@@ -14,7 +14,7 @@
  * - 五种风格预设：幽默 / 严肃 / 接地气 / 悬疑 / 温情
  */
 
-import React, { useState, useCallback, memo } from 'react';
+import React, { useReducer, useCallback, memo } from 'react';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
@@ -42,6 +42,10 @@ import { useDirectorStatus } from '@/hooks/useDirectorStatus';
 import { useCommentarySession } from '@/hooks/useCommentarySession';
 import { useCommentaryScript } from '@/hooks/useCommentaryScript';
 import { useCommentaryVoice } from '@/hooks/useCommentaryVoice';
+import {
+  commentaryPanelReducer,
+  initialCommentaryPanelState,
+} from './CommentaryPanel.reducer';
 import styles from './CommentaryPanel.module.less';
 import CommentaryScriptEditor from './CommentaryScriptEditor';
 import CommentaryStyleSelector from './CommentaryStyleSelector';
@@ -91,14 +95,9 @@ const CommentaryPanel: React.FC<CommentaryPanelProps> = ({
   durationSecs,
   disabled = false,
 }) => {
-  // ── UI 状态 ──────────────────────────────────────────────────────────
-  const [activeTab, setActiveTab] = useState<'script' | 'style' | 'voice' | 'timeline'>('script');
-  const [planConfirmOpen, setPlanConfirmOpen] = useState(false);
-  const [_reviseOpen, _setReviseOpen] = useState(false);
-  const [apiKey, setApiKey] = useState('');
-
-  // ── 风格选择状态 ──────────────────────────────────────────────────────
-  const [selectedStyle, setSelectedStyle] = useState<ScriptStylePreset>('conversational');
+  // ── UI 状态 (5 useState → 1 useReducer) ───────────────────────────────
+  const [state, dispatch] = useReducer(commentaryPanelReducer, initialCommentaryPanelState);
+  const { activeTab, planConfirmOpen, apiKey, selectedStyle } = state;
 
   // ── Hooks ────────────────────────────────────────────────────────────
   const { sessionId, directorStatus } = useCommentarySession(
@@ -135,14 +134,14 @@ const CommentaryPanel: React.FC<CommentaryPanelProps> = ({
   const handleGenerateScript = useCallback(async () => {
     if (!sessionId) return;
     await generate({ sessionId, subtitles, apiKey, selectedStyle, durationSecs });
-    setActiveTab('script');
-  }, [sessionId, subtitles, apiKey, selectedStyle, durationSecs, generate, setActiveTab]);
+    dispatch({ type: 'SET_ACTIVE_TAB', activeTab: 'script' });
+  }, [sessionId, subtitles, apiKey, selectedStyle, durationSecs, generate, dispatch]);
 
   const handleMultiStyleGenerate = useCallback(async () => {
     if (!sessionId) return;
     await multiGenerate({ sessionId, subtitles, apiKey, selectedStyles: [selectedStyle], durationSecs });
-    setActiveTab('script');
-  }, [sessionId, subtitles, apiKey, selectedStyle, durationSecs, multiGenerate, setActiveTab]);
+    dispatch({ type: 'SET_ACTIVE_TAB', activeTab: 'script' });
+  }, [sessionId, subtitles, apiKey, selectedStyle, durationSecs, multiGenerate, dispatch]);
 
   const handleSegmentChange = useCallback((index: number, text: string) => {
     updateSegment(index, text);
@@ -154,23 +153,23 @@ const CommentaryPanel: React.FC<CommentaryPanelProps> = ({
     try {
       await generateCommentaryPlan(sessionId, selectedStyle, durationSecs);
       toast.success('AI 导演计划已生成 ✨');
-      setPlanConfirmOpen(true);
+      dispatch({ type: 'SET_PLAN_CONFIRM_OPEN', planConfirmOpen: true });
     } catch (e) {
       toast.error(`生成失败: ${e}`);
     }
-  }, [sessionId, selectedStyle, durationSecs]);
+  }, [sessionId, selectedStyle, durationSecs, dispatch]);
 
   const handleApprovePlan = useCallback(async () => {
     if (!sessionId) return;
     try {
       await approveCommentaryPlan(sessionId);
-      setPlanConfirmOpen(false);
+      dispatch({ type: 'SET_PLAN_CONFIRM_OPEN', planConfirmOpen: false });
       toast.success('渲染已启动，请耐心等待 🎬');
-      setActiveTab('timeline');
+      dispatch({ type: 'SET_ACTIVE_TAB', activeTab: 'timeline' });
     } catch (e) {
       toast.error(`启动失败: ${e}`);
     }
-  }, [sessionId]);
+  }, [sessionId, dispatch]);
 
   // ── 预览 ─────────────────────────────────────────────────────────────
   const handlePreviewVoice = useCallback(async () => {
@@ -207,7 +206,7 @@ const CommentaryPanel: React.FC<CommentaryPanelProps> = ({
         )}
 
         {/* Tabs */}
-        <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as typeof activeTab)}>
+        <Tabs value={activeTab} onValueChange={(v) => dispatch({ type: 'SET_ACTIVE_TAB', activeTab: v as typeof activeTab })}>
           <TabsList className={styles.tabsList}>
             <TabsTrigger value="script"><FileText size={14} /> 脚本</TabsTrigger>
             <TabsTrigger value="style"><Sparkles size={14} /> 风格</TabsTrigger>
@@ -235,7 +234,7 @@ const CommentaryPanel: React.FC<CommentaryPanelProps> = ({
                   isGenerating={isGenerating}
                   onGenerate={() => {}}
                   apiKey={apiKey}
-                  onApiKeyChange={setApiKey}
+                  onApiKeyChange={(v) => dispatch({ type: 'SET_API_KEY', apiKey: v })}
                   onSegmentChange={handleSegmentChange}
                 />
               </div>
@@ -245,7 +244,7 @@ const CommentaryPanel: React.FC<CommentaryPanelProps> = ({
                 isGenerating={isGenerating}
                 onGenerate={handleGenerateScript}
                 apiKey={apiKey}
-                onApiKeyChange={setApiKey}
+                onApiKeyChange={(v) => dispatch({ type: 'SET_API_KEY', apiKey: v })}
                 onSegmentChange={handleSegmentChange}
               />
             )}
@@ -259,7 +258,7 @@ const CommentaryPanel: React.FC<CommentaryPanelProps> = ({
                 if (multiStyleMode) {
                   setSelectedStyles(s as ScriptStylePreset[]);
                 } else {
-                  setSelectedStyle(s as ScriptStylePreset);
+                  dispatch({ type: 'SET_SELECTED_STYLE', selectedStyle: s as ScriptStylePreset });
                 }
               }}
               multiSelect={multiStyleMode}
@@ -341,7 +340,7 @@ const CommentaryPanel: React.FC<CommentaryPanelProps> = ({
       </CardContent>
 
       {/* Plan 确认弹窗 */}
-      <Dialog open={planConfirmOpen} onOpenChange={setPlanConfirmOpen}>
+      <Dialog open={planConfirmOpen} onOpenChange={(open) => dispatch({ type: 'SET_PLAN_CONFIRM_OPEN', planConfirmOpen: open })}>
         <DialogContent>
           <DialogHeader>
             <DialogTitle>AI 导演计划已生成 ✨</DialogTitle>
@@ -369,7 +368,7 @@ const CommentaryPanel: React.FC<CommentaryPanelProps> = ({
             </div>
           )}
           <DialogFooter>
-            <Button variant="outline" onClick={() => setPlanConfirmOpen(false)}>
+            <Button variant="outline" onClick={() => dispatch({ type: 'SET_PLAN_CONFIRM_OPEN', planConfirmOpen: false })}>
               再改改
             </Button>
             <Button variant="default" onClick={handleApprovePlan}>


### PR DESCRIPTION
## 概述
CommentaryPanel 组件 5 个 useState → 1 个 useReducer 状态机化

## 变更
- 新增 `src/components/CommentaryPanel/CommentaryPanel.reducer.ts` (53 行)
  - 4 个 SET action: SET_ACTIVE_TAB / SET_PLAN_CONFIRM_OPEN / SET_API_KEY / SET_SELECTED_STYLE
- 主文件 `src/components/CommentaryPanel/CommentaryPanel.tsx` (384 → 383 行, -1 行)
  - `useReducer` 替换 5 个 `useState`

## 设计
- 参考 AIVisualizer/VideoSelector/VideoPlayer/WorkflowEditor/VideoUpload 模式: 直接 dispatch, 不建 setter 包装工厂
- _reviseOpen 死代码保留为 reducer state 字段 (Pitfall 12), 0 setter 暴露
- Dialog onOpenChange wrap (Pitfall 17): 接受 boolean 适配 dispatch action
- 子组件 onApiKeyChange prop 适配: (v: string) => dispatch wrap

## 验证
- `tsc --noEmit`: 0 错
- `eslint src/components/CommentaryPanel/`: 0 错 0 警告
- `npm run build`: ✓ built in 12.39s
- `vitest run`: 271/271 ✅

## 收益
- 状态集中化: 5 个独立 useState → 1 个 reducer 状态机
- 行为兼容: 0 调用方改动