### PR TITLE
refactor(hooks): add useBoundActions helper for reducer-action binding (Stage 8 PR-1.1)

### DIFF
--- a/src/shared/hooks/use-bound-actions.test.ts
+++ b/src/shared/hooks/use-bound-actions.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useBoundActions } from './use-bound-actions';
+
+describe('useBoundActions', () => {
+  it('returns a callable for each action creator', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+      INCREMENT: () => ({ type: 'INC' }),
+    };
+    const { result } = renderHook(() => useBoundActions(dispatch, actionCreators));
+    expect(typeof result.current.SET_X).toBe('function');
+    expect(typeof result.current.INCREMENT).toBe('function');
+  });
+
+  it('dispatches the action returned by each creator', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+    };
+    const { result } = renderHook(() => useBoundActions(dispatch, actionCreators));
+
+    result.current.SET_X(42);
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_X', payload: 42 });
+  });
+
+  it('handles void-returning action creators (e.g. INCREMENT with no payload)', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      INC: () => ({ type: 'INC' }),
+    };
+    const { result } = renderHook(() => useBoundActions(dispatch, actionCreators));
+
+    // INC creator takes no payload; result.current.INC is typed as (payload: void) => void
+    (result.current.INC as () => void)();
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'INC' });
+  });
+
+  it('returns a stable object reference across re-renders when creators are stable', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+    };
+    const { result, rerender } = renderHook(() => useBoundActions(dispatch, actionCreators));
+    const firstRef = result.current;
+    rerender();
+    expect(result.current).toBe(firstRef);
+  });
+
+  it('creates a new object reference when actionCreators change', () => {
+    const dispatch = vi.fn();
+    const creatorsA = { SET_X: (x: number) => ({ type: 'SET_X', payload: x }) };
+    const creatorsB = { SET_X: (x: number) => ({ type: 'SET_X', payload: x }) };
+    const { result, rerender } = renderHook(
+      ({ creators }) => useBoundActions(dispatch, creators),
+      { initialProps: { creators: creatorsA } },
+    );
+    const firstRef = result.current;
+    rerender({ creators: creatorsB });
+    expect(result.current).not.toBe(firstRef);
+  });
+
+  it('ignores non-function entries in actionCreators', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+    };
+    // Cast to any to inject a non-function entry and verify runtime safety
+    const dirtyCreators = actionCreators as unknown as Record<string, unknown>;
+    dirtyCreators.NOT_A_FUNCTION = 'oops';
+    const { result } = renderHook(() =>
+      useBoundActions(dispatch, dirtyCreators as typeof actionCreators),
+    );
+    expect(typeof result.current.SET_X).toBe('function');
+    expect((result.current as Record<string, unknown>).NOT_A_FUNCTION).toBeUndefined();
+  });
+});

--- a/src/shared/hooks/use-bound-actions.ts
+++ b/src/shared/hooks/use-bound-actions.ts
@@ -1,0 +1,56 @@
+/**
+ * use-bound-actions.ts
+ *
+ * 消除 reducer-hook 中的 10+ useCallback 包装 + 巨型 useMemo 聚合模板。
+ *
+ * 用法：
+ *   const { state, dispatch } = useReducerHookFactory(reducer, initialState);
+ *   const actions = useBoundActions(dispatch, {
+ *     SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+ *     INCREMENT: () => ({ type: 'INC' }),
+ *   });
+ *   actions.SET_X(42);  // 代替手写 useCallback(dispatch({ type: 'SET_X', payload: 42 }), [dispatch])
+ *
+ * 收益：
+ *   - 消除 N 个 useCallback 包装（N 通常 5-15）
+ *   - 消除巨型 useMemo 聚合对象
+ *   - 消费方代码 60-100 行 → 10-20 行
+ *
+ * 设计权衡：
+ *   - 返回的 actions 对象用 useMemo 稳定，依赖为 actionCreators + dispatch
+ *   - actionCreators 建议在 module-level 声明以保持稳定引用
+ *   - 复杂 action（非 SET 模式）仍可走 dispatch 直调，useBoundActions 不阻挡
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- 泛型 helper 内部需要 any 接收任意 action shape，由消费方收敛 */
+
+import { useMemo } from 'react';
+
+type ActionCreator<P> = (payload: P) => any;
+
+type BoundActions<A extends Record<string, ActionCreator<any>>> = {
+  [K in keyof A]: (payload: Parameters<A[K]>[0]) => void;
+};
+
+/**
+ * 将一组 action creator 绑定到 dispatch，返回稳定引用的 actions 对象。
+ *
+ * @param dispatch useReducer 的稳定 dispatch 函数
+ * @param actionCreators 模块级或稳定引用的 action creator 映射
+ * @returns 与 actionCreators 同名 key 的 actions 对象
+ */
+export function useBoundActions<A extends Record<string, ActionCreator<any>>>(
+  dispatch: React.Dispatch<any>,
+  actionCreators: A,
+): BoundActions<A> {
+  return useMemo(() => {
+    const bound: Record<string, (payload: any) => void> = {};
+    for (const key in actionCreators) {
+      const creator = actionCreators[key];
+      if (typeof creator === 'function') {
+        bound[key] = (payload: any) => dispatch(creator(payload));
+      }
+    }
+    return bound as BoundActions<A>;
+  }, [dispatch, actionCreators]);
+}


### PR DESCRIPTION
Stage 8 PR-1.1：新增 useBoundActions 工具消解 reducer-hook 中 10+ useCallback 包装。

- 新增 src/shared/hooks/use-bound-actions.ts（56 行）
- 6/6 单测通过
- 与 useReducerHookFactory 组合使用
- 公开 API：useBoundActions(dispatch, actionCreators) → actions map

后续 PR-1.2 / 1.3 将消费此工具迁移 3 个 reducer-hook。