### PR TITLE
refactor(hooks): migrate use-project-detail to useBoundActions pattern (Stage 8 PR-1.2)

### DIFF
--- a/src/hooks/use-project-detail.ts
+++ b/src/hooks/use-project-detail.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useReducerHookFactory } from '@/shared/hooks/use-reducer-hook';
+import { useBoundActions } from '@/shared/hooks/use-bound-actions';
 import type { AIScriptDraft } from '@/core/services/ai/script-service';
 import type { ScriptSegment } from '@/types';
 import {
@@ -21,66 +22,65 @@ interface UseProjectDetailResult {
   setDeleteConfirmOpen: (open: boolean) => void;
 }
 
+// module-level single-arg action creators — 稳定引用配合 useBoundActions useMemo。
+// 多参数 action（如 UPDATE_ACTIVE_SCRIPT_FROM_SEGMENTS）保持 inline 在 hook 内。
+const singleArgCreators = {
+  SET_ACTIVE_STEP: (step: string) => ({ type: 'SET_ACTIVE_STEP' as const, payload: step }),
+  SET_PROJECT: (project: ProjectDetailState['project']) => ({
+    type: 'SET_PROJECT' as const,
+    payload: project,
+  }),
+  UPDATE_PROJECT: (project: NonNullable<ProjectDetailState['project']>) => ({
+    type: 'UPDATE_PROJECT' as const,
+    payload: project,
+  }),
+  SET_ACTIVE_SCRIPT: (script: AIScriptDraft | null) => ({
+    type: 'SET_ACTIVE_SCRIPT' as const,
+    payload: script,
+  }),
+  UPDATE_ACTIVE_SCRIPT: (script: AIScriptDraft) => ({
+    type: 'UPDATE_ACTIVE_SCRIPT' as const,
+    payload: script,
+  }),
+  SET_AI_LOADING: (loading: boolean) => ({ type: 'SET_AI_LOADING' as const, payload: loading }),
+  SET_DRAWER_VISIBLE: (visible: boolean) => ({
+    type: 'SET_DRAWER_VISIBLE' as const,
+    payload: visible,
+  }),
+  SET_DELETE_CONFIRM_OPEN: (open: boolean) => ({
+    type: 'SET_DELETE_CONFIRM_OPEN' as const,
+    payload: open,
+  }),
+};
+
 export function useProjectDetail(): UseProjectDetailResult {
   const { state, dispatch } = useReducerHookFactory(projectDetailReducer, initialProjectDetailState);
+  const actions = useBoundActions(dispatch, singleArgCreators);
 
-  const setActiveStep = useCallback((step: string) => dispatch({ type:'SET_ACTIVE_STEP', payload: step }), [dispatch]);
-  const setProject = useCallback(
-    (project: ProjectDetailState['project']) => dispatch({ type:'SET_PROJECT', payload: project }),
-    [dispatch],
-  );
-  const updateProject = useCallback(
-    (project: NonNullable<ProjectDetailState['project']>) => dispatch({ type:'UPDATE_PROJECT', payload: project }),
-    [dispatch],
-  );
-  const setActiveScript = useCallback(
-    (script: AIScriptDraft | null) => dispatch({ type:'SET_ACTIVE_SCRIPT', payload: script }),
-    [dispatch],
-  );
-  const updateActiveScript = useCallback(
-    (script: AIScriptDraft) => dispatch({ type:'UPDATE_ACTIVE_SCRIPT', payload: script }),
-    [dispatch],
-  );
+  // 多参数 action inline（useBoundActions 只支持单参数场景）
   const updateActiveScriptFromSegments = useCallback(
     (segments: ScriptSegment[], activeScript: AIScriptDraft) =>
-      dispatch({ type:'UPDATE_ACTIVE_SCRIPT_FROM_SEGMENTS', payload: { segments, activeScript } }),
-    [dispatch],
-  );
-  const setAiLoading = useCallback((loading: boolean) => dispatch({ type:'SET_AI_LOADING', payload: loading }), [dispatch]);
-  const setDrawerVisible = useCallback(
-    (visible: boolean) => dispatch({ type:'SET_DRAWER_VISIBLE', payload: visible }),
-    [dispatch],
-  );
-  const setDeleteConfirmOpen = useCallback(
-    (open: boolean) => dispatch({ type:'SET_DELETE_CONFIRM_OPEN', payload: open }),
+      dispatch({
+        type: 'UPDATE_ACTIVE_SCRIPT_FROM_SEGMENTS',
+        payload: { segments, activeScript },
+      }),
     [dispatch],
   );
 
   return useMemo(
     () => ({
       state,
-      setActiveStep,
-      setProject,
-      updateProject,
-      setActiveScript,
-      updateActiveScript,
+      setActiveStep: actions.SET_ACTIVE_STEP,
+      setProject: actions.SET_PROJECT,
+      updateProject: actions.UPDATE_PROJECT,
+      setActiveScript: actions.SET_ACTIVE_SCRIPT,
+      updateActiveScript: actions.UPDATE_ACTIVE_SCRIPT,
       updateActiveScriptFromSegments,
-      setAiLoading,
-      setDrawerVisible,
-      setDeleteConfirmOpen,
+      setAiLoading: actions.SET_AI_LOADING,
+      setDrawerVisible: actions.SET_DRAWER_VISIBLE,
+      setDeleteConfirmOpen: actions.SET_DELETE_CONFIRM_OPEN,
     }),
-    [
-      state,
-      setActiveStep,
-      setProject,
-      updateProject,
-      setActiveScript,
-      updateActiveScript,
-      updateActiveScriptFromSegments,
-      setAiLoading,
-      setDrawerVisible,
-      setDeleteConfirmOpen,
-    ],
+    [state, actions, updateActiveScriptFromSegments],
   );
 }
 

--- a/src/shared/hooks/use-bound-actions.test.ts
+++ b/src/shared/hooks/use-bound-actions.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useBoundActions } from './use-bound-actions';
+
+describe('useBoundActions', () => {
+  it('returns a callable for each action creator', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+      INCREMENT: () => ({ type: 'INC' }),
+    };
+    const { result } = renderHook(() => useBoundActions(dispatch, actionCreators));
+    expect(typeof result.current.SET_X).toBe('function');
+    expect(typeof result.current.INCREMENT).toBe('function');
+  });
+
+  it('dispatches the action returned by each creator', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+    };
+    const { result } = renderHook(() => useBoundActions(dispatch, actionCreators));
+
+    result.current.SET_X(42);
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_X', payload: 42 });
+  });
+
+  it('handles void-returning action creators (e.g. INCREMENT with no payload)', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      INC: () => ({ type: 'INC' }),
+    };
+    const { result } = renderHook(() => useBoundActions(dispatch, actionCreators));
+
+    // INC creator takes no payload; result.current.INC is typed as (payload: void) => void
+    (result.current.INC as () => void)();
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'INC' });
+  });
+
+  it('returns a stable object reference across re-renders when creators are stable', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+    };
+    const { result, rerender } = renderHook(() => useBoundActions(dispatch, actionCreators));
+    const firstRef = result.current;
+    rerender();
+    expect(result.current).toBe(firstRef);
+  });
+
+  it('creates a new object reference when actionCreators change', () => {
+    const dispatch = vi.fn();
+    const creatorsA = { SET_X: (x: number) => ({ type: 'SET_X', payload: x }) };
+    const creatorsB = { SET_X: (x: number) => ({ type: 'SET_X', payload: x }) };
+    const { result, rerender } = renderHook(
+      ({ creators }) => useBoundActions(dispatch, creators),
+      { initialProps: { creators: creatorsA } },
+    );
+    const firstRef = result.current;
+    rerender({ creators: creatorsB });
+    expect(result.current).not.toBe(firstRef);
+  });
+
+  it('ignores non-function entries in actionCreators', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+    };
+    // Cast to any to inject a non-function entry and verify runtime safety
+    const dirtyCreators = actionCreators as unknown as Record<string, unknown>;
+    dirtyCreators.NOT_A_FUNCTION = 'oops';
+    const { result } = renderHook(() =>
+      useBoundActions(dispatch, dirtyCreators as typeof actionCreators),
+    );
+    expect(typeof result.current.SET_X).toBe('function');
+    expect((result.current as Record<string, unknown>).NOT_A_FUNCTION).toBeUndefined();
+  });
+});

--- a/src/shared/hooks/use-bound-actions.ts
+++ b/src/shared/hooks/use-bound-actions.ts
@@ -1,0 +1,56 @@
+/**
+ * use-bound-actions.ts
+ *
+ * 消除 reducer-hook 中的 10+ useCallback 包装 + 巨型 useMemo 聚合模板。
+ *
+ * 用法：
+ *   const { state, dispatch } = useReducerHookFactory(reducer, initialState);
+ *   const actions = useBoundActions(dispatch, {
+ *     SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+ *     INCREMENT: () => ({ type: 'INC' }),
+ *   });
+ *   actions.SET_X(42);  // 代替手写 useCallback(dispatch({ type: 'SET_X', payload: 42 }), [dispatch])
+ *
+ * 收益：
+ *   - 消除 N 个 useCallback 包装（N 通常 5-15）
+ *   - 消除巨型 useMemo 聚合对象
+ *   - 消费方代码 60-100 行 → 10-20 行
+ *
+ * 设计权衡：
+ *   - 返回的 actions 对象用 useMemo 稳定，依赖为 actionCreators + dispatch
+ *   - actionCreators 建议在 module-level 声明以保持稳定引用
+ *   - 复杂 action（非 SET 模式）仍可走 dispatch 直调，useBoundActions 不阻挡
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- 泛型 helper 内部需要 any 接收任意 action shape，由消费方收敛 */
+
+import { useMemo } from 'react';
+
+type ActionCreator<P> = (payload: P) => any;
+
+type BoundActions<A extends Record<string, ActionCreator<any>>> = {
+  [K in keyof A]: (payload: Parameters<A[K]>[0]) => void;
+};
+
+/**
+ * 将一组 action creator 绑定到 dispatch，返回稳定引用的 actions 对象。
+ *
+ * @param dispatch useReducer 的稳定 dispatch 函数
+ * @param actionCreators 模块级或稳定引用的 action creator 映射
+ * @returns 与 actionCreators 同名 key 的 actions 对象
+ */
+export function useBoundActions<A extends Record<string, ActionCreator<any>>>(
+  dispatch: React.Dispatch<any>,
+  actionCreators: A,
+): BoundActions<A> {
+  return useMemo(() => {
+    const bound: Record<string, (payload: any) => void> = {};
+    for (const key in actionCreators) {
+      const creator = actionCreators[key];
+      if (typeof creator === 'function') {
+        bound[key] = (payload: any) => dispatch(creator(payload));
+      }
+    }
+    return bound as BoundActions<A>;
+  }, [dispatch, actionCreators]);
+}


### PR DESCRIPTION
Stage 8 PR-1.2：use-project-detail 迁移到 useBoundActions 工厂。9 个 useCallback 包装 → 8 个 module-level actionCreator + 1 个 useBoundActions。公开 API 零变化。