### PR TITLE
refactor(hooks): migrate use-script-detail & use-subtitle-extraction to useBoundActions (Stage 8 PR-1.3)

### DIFF
--- a/src/hooks/use-project-detail.ts
+++ b/src/hooks/use-project-detail.ts
@@ -1,5 +1,6 @@
 import { useCallback, useMemo } from 'react';
 import { useReducerHookFactory } from '@/shared/hooks/use-reducer-hook';
+import { useBoundActions } from '@/shared/hooks/use-bound-actions';
 import type { AIScriptDraft } from '@/core/services/ai/script-service';
 import type { ScriptSegment } from '@/types';
 import {
@@ -21,66 +22,65 @@ interface UseProjectDetailResult {
   setDeleteConfirmOpen: (open: boolean) => void;
 }
 
+// module-level single-arg action creators — 稳定引用配合 useBoundActions useMemo。
+// 多参数 action（如 UPDATE_ACTIVE_SCRIPT_FROM_SEGMENTS）保持 inline 在 hook 内。
+const singleArgCreators = {
+  SET_ACTIVE_STEP: (step: string) => ({ type: 'SET_ACTIVE_STEP' as const, payload: step }),
+  SET_PROJECT: (project: ProjectDetailState['project']) => ({
+    type: 'SET_PROJECT' as const,
+    payload: project,
+  }),
+  UPDATE_PROJECT: (project: NonNullable<ProjectDetailState['project']>) => ({
+    type: 'UPDATE_PROJECT' as const,
+    payload: project,
+  }),
+  SET_ACTIVE_SCRIPT: (script: AIScriptDraft | null) => ({
+    type: 'SET_ACTIVE_SCRIPT' as const,
+    payload: script,
+  }),
+  UPDATE_ACTIVE_SCRIPT: (script: AIScriptDraft) => ({
+    type: 'UPDATE_ACTIVE_SCRIPT' as const,
+    payload: script,
+  }),
+  SET_AI_LOADING: (loading: boolean) => ({ type: 'SET_AI_LOADING' as const, payload: loading }),
+  SET_DRAWER_VISIBLE: (visible: boolean) => ({
+    type: 'SET_DRAWER_VISIBLE' as const,
+    payload: visible,
+  }),
+  SET_DELETE_CONFIRM_OPEN: (open: boolean) => ({
+    type: 'SET_DELETE_CONFIRM_OPEN' as const,
+    payload: open,
+  }),
+};
+
 export function useProjectDetail(): UseProjectDetailResult {
   const { state, dispatch } = useReducerHookFactory(projectDetailReducer, initialProjectDetailState);
+  const actions = useBoundActions(dispatch, singleArgCreators);
 
-  const setActiveStep = useCallback((step: string) => dispatch({ type:'SET_ACTIVE_STEP', payload: step }), [dispatch]);
-  const setProject = useCallback(
-    (project: ProjectDetailState['project']) => dispatch({ type:'SET_PROJECT', payload: project }),
-    [dispatch],
-  );
-  const updateProject = useCallback(
-    (project: NonNullable<ProjectDetailState['project']>) => dispatch({ type:'UPDATE_PROJECT', payload: project }),
-    [dispatch],
-  );
-  const setActiveScript = useCallback(
-    (script: AIScriptDraft | null) => dispatch({ type:'SET_ACTIVE_SCRIPT', payload: script }),
-    [dispatch],
-  );
-  const updateActiveScript = useCallback(
-    (script: AIScriptDraft) => dispatch({ type:'UPDATE_ACTIVE_SCRIPT', payload: script }),
-    [dispatch],
-  );
+  // 多参数 action inline（useBoundActions 只支持单参数场景）
   const updateActiveScriptFromSegments = useCallback(
     (segments: ScriptSegment[], activeScript: AIScriptDraft) =>
-      dispatch({ type:'UPDATE_ACTIVE_SCRIPT_FROM_SEGMENTS', payload: { segments, activeScript } }),
-    [dispatch],
-  );
-  const setAiLoading = useCallback((loading: boolean) => dispatch({ type:'SET_AI_LOADING', payload: loading }), [dispatch]);
-  const setDrawerVisible = useCallback(
-    (visible: boolean) => dispatch({ type:'SET_DRAWER_VISIBLE', payload: visible }),
-    [dispatch],
-  );
-  const setDeleteConfirmOpen = useCallback(
-    (open: boolean) => dispatch({ type:'SET_DELETE_CONFIRM_OPEN', payload: open }),
+      dispatch({
+        type: 'UPDATE_ACTIVE_SCRIPT_FROM_SEGMENTS',
+        payload: { segments, activeScript },
+      }),
     [dispatch],
   );
 
   return useMemo(
     () => ({
       state,
-      setActiveStep,
-      setProject,
-      updateProject,
-      setActiveScript,
-      updateActiveScript,
+      setActiveStep: actions.SET_ACTIVE_STEP,
+      setProject: actions.SET_PROJECT,
+      updateProject: actions.UPDATE_PROJECT,
+      setActiveScript: actions.SET_ACTIVE_SCRIPT,
+      updateActiveScript: actions.UPDATE_ACTIVE_SCRIPT,
       updateActiveScriptFromSegments,
-      setAiLoading,
-      setDrawerVisible,
-      setDeleteConfirmOpen,
+      setAiLoading: actions.SET_AI_LOADING,
+      setDrawerVisible: actions.SET_DRAWER_VISIBLE,
+      setDeleteConfirmOpen: actions.SET_DELETE_CONFIRM_OPEN,
     }),
-    [
-      state,
-      setActiveStep,
-      setProject,
-      updateProject,
-      setActiveScript,
-      updateActiveScript,
-      updateActiveScriptFromSegments,
-      setAiLoading,
-      setDrawerVisible,
-      setDeleteConfirmOpen,
-    ],
+    [state, actions, updateActiveScriptFromSegments],
   );
 }
 

--- a/src/hooks/use-script-detail.ts
+++ b/src/hooks/use-script-detail.ts
@@ -1,5 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useReducerHookFactory } from '@/shared/hooks/use-reducer-hook';
+import { useBoundActions } from '@/shared/hooks/use-bound-actions';
 import type { AIScriptDraft } from '@/core/services/ai/script-service';
 import type { ScriptSegment } from '@/types';
 import {
@@ -24,80 +25,56 @@ interface UseScriptDetailResult {
   resetForReload: () => void;
 }
 
+// module-level action creators — 稳定引用配合 useBoundActions useMemo
+const actionCreators = {
+  SET_LOADING: (loading: boolean) => ({ type: 'SET_LOADING' as const, payload: loading }),
+  SET_PROJECT: (project: ScriptDetailState['project']) => ({
+    type: 'SET_PROJECT' as const,
+    payload: project,
+  }),
+  SET_SCRIPT: (script: AIScriptDraft | null) => ({ type: 'SET_SCRIPT' as const, payload: script }),
+  SET_SEGMENTS: (segments: ScriptSegment[]) => ({
+    type: 'SET_SEGMENTS' as const,
+    payload: segments,
+  }),
+  SET_LOAD_ERROR: (loadError: string) => ({ type: 'SET_LOAD_ERROR' as const, payload: loadError }),
+  INCREMENT_RELOAD_TOKEN: () => ({ type: 'INCREMENT_RELOAD_TOKEN' as const, payload: undefined }),
+  SET_IS_SAVING: (isSaving: boolean) => ({ type: 'SET_IS_SAVING' as const, payload: isSaving }),
+  SET_IS_EXPORTING: (isExporting: boolean) => ({
+    type: 'SET_IS_EXPORTING' as const,
+    payload: isExporting,
+  }),
+  SET_IS_DELETING: (isDeleting: boolean) => ({ type: 'SET_IS_DELETING' as const, payload: isDeleting }),
+  SET_DELETE_CONFIRM_OPEN: (open: boolean) => ({
+    type: 'SET_DELETE_CONFIRM_OPEN' as const,
+    payload: open,
+  }),
+  RESET: () => ({ type: 'RESET' as const, payload: undefined }),
+};
+
 export function useScriptDetail(): UseScriptDetailResult {
   const { state, dispatch } = useReducerHookFactory(scriptDetailReducer, initialScriptDetailState);
-
-  const setLoading = useCallback((loading: boolean) => dispatch({ type:'SET_LOADING', payload: loading }), [dispatch]);
-  const setProject = useCallback(
-    (project: ScriptDetailState['project']) => dispatch({ type:'SET_PROJECT', payload: project }),
-    [dispatch],
-  );
-  const setScript = useCallback(
-    (script: AIScriptDraft | null) => dispatch({ type:'SET_SCRIPT', payload: script }),
-    [dispatch],
-  );
-  const setSegments = useCallback(
-    (segments: ScriptSegment[]) => dispatch({ type:'SET_SEGMENTS', payload: segments }),
-    [dispatch],
-  );
-  const setLoadError = useCallback(
-    (loadError: string) => dispatch({ type:'SET_LOAD_ERROR', payload: loadError }),
-    [dispatch],
-  );
-  const incrementReloadToken = useCallback(
-    () => dispatch({ type:'INCREMENT_RELOAD_TOKEN', payload: undefined }),
-    [dispatch],
-  );
-  const setIsSaving = useCallback(
-    (isSaving: boolean) => dispatch({ type:'SET_IS_SAVING', payload: isSaving }),
-    [dispatch],
-  );
-  const setIsExporting = useCallback(
-    (isExporting: boolean) => dispatch({ type:'SET_IS_EXPORTING', payload: isExporting }),
-    [dispatch],
-  );
-  const setIsDeleting = useCallback(
-    (isDeleting: boolean) => dispatch({ type:'SET_IS_DELETING', payload: isDeleting }),
-    [dispatch],
-  );
-  const setDeleteConfirmOpen = useCallback(
-    (open: boolean) => dispatch({ type:'SET_DELETE_CONFIRM_OPEN', payload: open }),
-    [dispatch],
-  );
-  const resetForLoad = useCallback(() => dispatch({ type:'RESET', payload: undefined }), [dispatch]);
-  const resetForReload = useCallback(() => dispatch({ type:'RESET', payload: undefined }), [dispatch]);
+  const actions = useBoundActions(dispatch, actionCreators);
 
   return useMemo(
     () => ({
       state,
-      setLoading,
-      setProject,
-      setScript,
-      setSegments,
-      setLoadError,
-      incrementReloadToken,
-      setIsSaving,
-      setIsExporting,
-      setIsDeleting,
-      setDeleteConfirmOpen,
-      resetForLoad,
-      resetForReload,
+      setLoading: actions.SET_LOADING,
+      setProject: actions.SET_PROJECT,
+      setScript: actions.SET_SCRIPT,
+      setSegments: actions.SET_SEGMENTS,
+      setLoadError: actions.SET_LOAD_ERROR,
+      setIsSaving: actions.SET_IS_SAVING,
+      setIsExporting: actions.SET_IS_EXPORTING,
+      setIsDeleting: actions.SET_IS_DELETING,
+      setDeleteConfirmOpen: actions.SET_DELETE_CONFIRM_OPEN,
+      incrementReloadToken: () => actions.INCREMENT_RELOAD_TOKEN(undefined),
+      // resetForLoad 和 resetForReload 历史上都 dispatch RESET action（共用 reducer），
+      // 这里用同样的 RESET action 绑定两个不同语义名，保持 API 兼容。
+      resetForLoad: () => actions.RESET(undefined),
+      resetForReload: () => actions.RESET(undefined),
     }),
-    [
-      state,
-      setLoading,
-      setProject,
-      setScript,
-      setSegments,
-      setLoadError,
-      incrementReloadToken,
-      setIsSaving,
-      setIsExporting,
-      setIsDeleting,
-      setDeleteConfirmOpen,
-      resetForLoad,
-      resetForReload,
-    ],
+    [state, actions],
   );
 }
 

--- a/src/hooks/use-subtitle-extraction.ts
+++ b/src/hooks/use-subtitle-extraction.ts
@@ -1,5 +1,6 @@
-import { useCallback, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useReducerHookFactory } from '@/shared/hooks/use-reducer-hook';
+import { useBoundActions } from '@/shared/hooks/use-bound-actions';
 import {
   initialSubtitleExtractorState,
   subtitleExtractorReducer,
@@ -26,83 +27,72 @@ interface UseSubtitleExtractionResult {
   resetForExtract: () => void;
 }
 
-export function useSubtitleExtraction(): UseSubtitleExtractionResult {
-  const { state, dispatch } = useReducerHookFactory(subtitleExtractorReducer, initialSubtitleExtractorState);
+// module-level single-arg action creators — 稳定引用配合 useBoundActions useMemo。
+// 多参数 action（incrementProgress）保持 inline 在 hook 内。
+const singleArgCreators = {
+  SET_FORMAT: (format: SubtitleFormat) => ({ type: 'SET_FORMAT' as const, payload: format }),
+  SET_TRANSLATE: (translate: boolean) => ({ type: 'SET_TRANSLATE' as const, payload: translate }),
+  SET_IS_EXTRACTING: (isExtracting: boolean) => ({
+    type: 'SET_IS_EXTRACTING' as const,
+    payload: isExtracting,
+  }),
+  SET_PROGRESS: (progress: number) => ({ type: 'SET_PROGRESS' as const, payload: progress }),
+  SET_EXTRACTED_SUBTITLES: (subtitles: SubtitleSegment[]) => ({
+    type: 'SET_EXTRACTED_SUBTITLES' as const,
+    payload: subtitles,
+  }),
+  SET_EDITING_ID: (editingId: string | null) => ({
+    type: 'SET_EDITING_ID' as const,
+    payload: editingId,
+  }),
+  SET_EDITING_TEXT: (editingText: string) => ({
+    type: 'SET_EDITING_TEXT' as const,
+    payload: editingText,
+  }),
+  SET_ACTIVE_SUB_ID: (activeSubId: string | null) => ({
+    type: 'SET_ACTIVE_SUB_ID' as const,
+    payload: activeSubId,
+  }),
+  SET_VIDEO_DURATION: (videoDuration: number) => ({
+    type: 'SET_VIDEO_DURATION' as const,
+    payload: videoDuration,
+  }),
+  START_EDIT: (sub: SubtitleSegment) => ({ type: 'START_EDIT' as const, payload: sub }),
+  CANCEL_EDIT: () => ({ type: 'CANCEL_EDIT' as const, payload: undefined }),
+  RESET_FOR_EXTRACT: () => ({ type: 'RESET_FOR_EXTRACT' as const, payload: undefined }),
+};
 
-  const setFormat = useCallback((format: SubtitleFormat) => dispatch({ type:'SET_FORMAT', payload: format }), [dispatch]);
-  const setTranslate = useCallback((translate: boolean) => dispatch({ type:'SET_TRANSLATE', payload: translate }), [dispatch]);
-  const setIsExtracting = useCallback(
-    (isExtracting: boolean) => dispatch({ type:'SET_IS_EXTRACTING', payload: isExtracting }),
-    [dispatch],
+export function useSubtitleExtraction(): UseSubtitleExtractionResult {
+  const { state, dispatch } = useReducerHookFactory(
+    subtitleExtractorReducer,
+    initialSubtitleExtractorState,
   );
-  const setProgress = useCallback((progress: number) => dispatch({ type:'SET_PROGRESS', payload: progress }), [dispatch]);
-  const incrementProgress = useCallback(
-    (delta: number, cap: number) => dispatch({ type:'INCREMENT_PROGRESS', payload: { delta, cap } }),
-    [dispatch],
-  );
-  const setExtractedSubtitles = useCallback(
-    (subtitles: SubtitleSegment[]) => dispatch({ type:'SET_EXTRACTED_SUBTITLES', payload: subtitles }),
-    [dispatch],
-  );
-  const updateSubtitleText = useCallback(
-    (id: string, text: string) => dispatch({ type:'UPDATE_SUBTITLE_TEXT', payload: { id, text } }),
-    [dispatch],
-  );
-  const setEditingId = useCallback(
-    (editingId: string | null) => dispatch({ type:'SET_EDITING_ID', payload: editingId }),
-    [dispatch],
-  );
-  const setEditingText = useCallback(
-    (editingText: string) => dispatch({ type:'SET_EDITING_TEXT', payload: editingText }),
-    [dispatch],
-  );
-  const setActiveSubId = useCallback(
-    (activeSubId: string | null) => dispatch({ type:'SET_ACTIVE_SUB_ID', payload: activeSubId }),
-    [dispatch],
-  );
-  const setVideoDuration = useCallback(
-    (videoDuration: number) => dispatch({ type:'SET_VIDEO_DURATION', payload: videoDuration }),
-    [dispatch],
-  );
-  const startEdit = useCallback((sub: SubtitleSegment) => dispatch({ type: 'START_EDIT', payload: sub }), [dispatch]);
-  const cancelEdit = useCallback(() => dispatch({ type:'CANCEL_EDIT', payload: undefined }), [dispatch]);
-  const resetForExtract = useCallback(() => dispatch({ type:'RESET_FOR_EXTRACT', payload: undefined }), [dispatch]);
+  const actions = useBoundActions(dispatch, singleArgCreators);
 
   return useMemo(
     () => ({
       state,
-      setFormat,
-      setTranslate,
-      setIsExtracting,
-      setProgress,
-      incrementProgress,
-      setExtractedSubtitles,
-      updateSubtitleText,
-      setEditingId,
-      setEditingText,
-      setActiveSubId,
-      setVideoDuration,
-      startEdit,
-      cancelEdit,
-      resetForExtract,
+      setFormat: actions.SET_FORMAT,
+      setTranslate: actions.SET_TRANSLATE,
+      setIsExtracting: actions.SET_IS_EXTRACTING,
+      setProgress: actions.SET_PROGRESS,
+      setExtractedSubtitles: actions.SET_EXTRACTED_SUBTITLES,
+      // UPDATE_SUBTITLE_TEXT 是 (id, text) → { id, text } 多参数 inline
+      updateSubtitleText: (id: string, text: string) =>
+        dispatch({ type: 'UPDATE_SUBTITLE_TEXT', payload: { id, text } }),
+      setEditingId: actions.SET_EDITING_ID,
+      setEditingText: actions.SET_EDITING_TEXT,
+      setActiveSubId: actions.SET_ACTIVE_SUB_ID,
+      setVideoDuration: actions.SET_VIDEO_DURATION,
+      startEdit: actions.START_EDIT,
+      // void actions（无参 API）需要 1 行 wrapper：bound signature 是 (payload: undefined) => void
+      cancelEdit: () => actions.CANCEL_EDIT(undefined),
+      resetForExtract: () => actions.RESET_FOR_EXTRACT(undefined),
+      // incrementProgress 是 2 参数 (delta, cap) → { delta, cap }，保持 inline
+      incrementProgress: (delta: number, cap: number) =>
+        dispatch({ type: 'INCREMENT_PROGRESS', payload: { delta, cap } }),
     }),
-    [
-      state,
-      setFormat,
-      setTranslate,
-      setIsExtracting,
-      setProgress,
-      incrementProgress,
-      setExtractedSubtitles,
-      updateSubtitleText,
-      setEditingId,
-      setEditingText,
-      setActiveSubId,
-      setVideoDuration,
-      startEdit,
-      cancelEdit,
-      resetForExtract,
-    ],
+    [state, actions, dispatch],
   );
 }
 

--- a/src/shared/hooks/use-bound-actions.test.ts
+++ b/src/shared/hooks/use-bound-actions.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useBoundActions } from './use-bound-actions';
+
+describe('useBoundActions', () => {
+  it('returns a callable for each action creator', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+      INCREMENT: () => ({ type: 'INC' }),
+    };
+    const { result } = renderHook(() => useBoundActions(dispatch, actionCreators));
+    expect(typeof result.current.SET_X).toBe('function');
+    expect(typeof result.current.INCREMENT).toBe('function');
+  });
+
+  it('dispatches the action returned by each creator', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+    };
+    const { result } = renderHook(() => useBoundActions(dispatch, actionCreators));
+
+    result.current.SET_X(42);
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'SET_X', payload: 42 });
+  });
+
+  it('handles void-returning action creators (e.g. INCREMENT with no payload)', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      INC: () => ({ type: 'INC' }),
+    };
+    const { result } = renderHook(() => useBoundActions(dispatch, actionCreators));
+
+    // INC creator takes no payload; result.current.INC is typed as (payload: void) => void
+    (result.current.INC as () => void)();
+
+    expect(dispatch).toHaveBeenCalledWith({ type: 'INC' });
+  });
+
+  it('returns a stable object reference across re-renders when creators are stable', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+    };
+    const { result, rerender } = renderHook(() => useBoundActions(dispatch, actionCreators));
+    const firstRef = result.current;
+    rerender();
+    expect(result.current).toBe(firstRef);
+  });
+
+  it('creates a new object reference when actionCreators change', () => {
+    const dispatch = vi.fn();
+    const creatorsA = { SET_X: (x: number) => ({ type: 'SET_X', payload: x }) };
+    const creatorsB = { SET_X: (x: number) => ({ type: 'SET_X', payload: x }) };
+    const { result, rerender } = renderHook(
+      ({ creators }) => useBoundActions(dispatch, creators),
+      { initialProps: { creators: creatorsA } },
+    );
+    const firstRef = result.current;
+    rerender({ creators: creatorsB });
+    expect(result.current).not.toBe(firstRef);
+  });
+
+  it('ignores non-function entries in actionCreators', () => {
+    const dispatch = vi.fn();
+    const actionCreators = {
+      SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+    };
+    // Cast to any to inject a non-function entry and verify runtime safety
+    const dirtyCreators = actionCreators as unknown as Record<string, unknown>;
+    dirtyCreators.NOT_A_FUNCTION = 'oops';
+    const { result } = renderHook(() =>
+      useBoundActions(dispatch, dirtyCreators as typeof actionCreators),
+    );
+    expect(typeof result.current.SET_X).toBe('function');
+    expect((result.current as Record<string, unknown>).NOT_A_FUNCTION).toBeUndefined();
+  });
+});

--- a/src/shared/hooks/use-bound-actions.ts
+++ b/src/shared/hooks/use-bound-actions.ts
@@ -1,0 +1,56 @@
+/**
+ * use-bound-actions.ts
+ *
+ * 消除 reducer-hook 中的 10+ useCallback 包装 + 巨型 useMemo 聚合模板。
+ *
+ * 用法：
+ *   const { state, dispatch } = useReducerHookFactory(reducer, initialState);
+ *   const actions = useBoundActions(dispatch, {
+ *     SET_X: (x: number) => ({ type: 'SET_X', payload: x }),
+ *     INCREMENT: () => ({ type: 'INC' }),
+ *   });
+ *   actions.SET_X(42);  // 代替手写 useCallback(dispatch({ type: 'SET_X', payload: 42 }), [dispatch])
+ *
+ * 收益：
+ *   - 消除 N 个 useCallback 包装（N 通常 5-15）
+ *   - 消除巨型 useMemo 聚合对象
+ *   - 消费方代码 60-100 行 → 10-20 行
+ *
+ * 设计权衡：
+ *   - 返回的 actions 对象用 useMemo 稳定，依赖为 actionCreators + dispatch
+ *   - actionCreators 建议在 module-level 声明以保持稳定引用
+ *   - 复杂 action（非 SET 模式）仍可走 dispatch 直调，useBoundActions 不阻挡
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- 泛型 helper 内部需要 any 接收任意 action shape，由消费方收敛 */
+
+import { useMemo } from 'react';
+
+type ActionCreator<P> = (payload: P) => any;
+
+type BoundActions<A extends Record<string, ActionCreator<any>>> = {
+  [K in keyof A]: (payload: Parameters<A[K]>[0]) => void;
+};
+
+/**
+ * 将一组 action creator 绑定到 dispatch，返回稳定引用的 actions 对象。
+ *
+ * @param dispatch useReducer 的稳定 dispatch 函数
+ * @param actionCreators 模块级或稳定引用的 action creator 映射
+ * @returns 与 actionCreators 同名 key 的 actions 对象
+ */
+export function useBoundActions<A extends Record<string, ActionCreator<any>>>(
+  dispatch: React.Dispatch<any>,
+  actionCreators: A,
+): BoundActions<A> {
+  return useMemo(() => {
+    const bound: Record<string, (payload: any) => void> = {};
+    for (const key in actionCreators) {
+      const creator = actionCreators[key];
+      if (typeof creator === 'function') {
+        bound[key] = (payload: any) => dispatch(creator(payload));
+      }
+    }
+    return bound as BoundActions<A>;
+  }, [dispatch, actionCreators]);
+}


### PR DESCRIPTION
Stage 8 PR-1.3：批量迁移 2 个 reducer-hook。use-script-detail 105→82（-23 行），use-subtitle-extraction 110→100（-10 行）。