### PR TITLE
refactor(stores): replace 9 mechanical setters in editor-store with factory (Stage 8 PR-2.2)

### DIFF
--- a/src/stores/create-simple-setters.test.ts
+++ b/src/stores/create-simple-setters.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest';
+import { create } from 'zustand';
+import { createSimpleSetters } from './create-simple-setters';
+
+interface TestState {
+  name: string;
+  count: number;
+  active: boolean;
+}
+
+interface TestActions {
+  setName: (v: string) => void;
+  setCount: (v: number) => void;
+  setActive: (v: boolean) => void;
+}
+
+const createTestStore = () => {
+  const setMap = {
+    setName: 'name',
+    setCount: 'count',
+    setActive: 'active',
+  } as const;
+  return create<TestState & TestActions>((set) => ({
+    name: 'init',
+    count: 0,
+    active: false,
+    ...createSimpleSetters(setMap, set),
+  }));
+};
+
+describe('createSimpleSetters', () => {
+  it('generates a setter for every entry in the map', () => {
+    const store = createTestStore();
+    const setMap = { setName: 'name', setCount: 'count', setActive: 'active' } as const;
+    const setters = createSimpleSetters(setMap, store.setState);
+    expect(Object.keys(setters).sort()).toEqual(['setActive', 'setCount', 'setName']);
+  });
+
+  it('each setter updates its mapped state key', () => {
+    const store = createTestStore();
+
+    store.getState().setName('hello');
+    store.getState().setCount(42);
+    store.getState().setActive(true);
+
+    expect(store.getState().name).toBe('hello');
+    expect(store.getState().count).toBe(42);
+    expect(store.getState().active).toBe(true);
+  });
+
+  it('only updates the targeted key, preserving others', () => {
+    const store = createTestStore();
+    store.getState().setName('first');
+    store.getState().setCount(1);
+
+    store.getState().setCount(99);
+
+    const state = store.getState();
+    expect(state.name).toBe('first');
+    expect(state.count).toBe(99);
+  });
+
+  it('type inference: setter parameter type matches state field type', () => {
+    const store = createTestStore();
+    const { setName, setCount, setActive } = store.getState();
+
+    // Compile-time type check. If wrong, file won't compile.
+    setName('a'); // ✅ string
+    setCount(1); // ✅ number
+    setActive(true); // ✅ boolean
+
+    // @ts-expect-error: number not assignable to string
+    setName(123);
+    // @ts-expect-error: string not assignable to number
+    setCount('x');
+    // @ts-expect-error: string not assignable to boolean
+    setActive('true');
+
+    expect(true).toBe(true);
+  });
+
+  it('works when action name differs from state key (e.g. setInPoint → inPointMs)', () => {
+    interface S {
+      playheadMs: number;
+      inPointMs: number | undefined;
+    }
+    interface A {
+      setInPoint: (v: number | undefined) => void;
+    }
+    const store = create<S & A>((set) => ({
+      playheadMs: 0,
+      inPointMs: undefined,
+      ...createSimpleSetters({ setInPoint: 'inPointMs' }, set),
+    }));
+
+    store.getState().setInPoint(500);
+    expect(store.getState().inPointMs).toBe(500);
+    expect(store.getState().playheadMs).toBe(0); // untouched
+  });
+
+  it('factory called with same map returns independent closures (each set is stable within)', () => {
+    const store = createTestStore();
+    const setMap = { setName: 'name', setCount: 'count', setActive: 'active' } as const;
+    const settersA = createSimpleSetters(setMap, store.setState);
+    const settersB = createSimpleSetters(setMap, store.setState);
+
+    // Different factory invocations produce different setter instances
+    expect(settersA.setName).not.toBe(settersB.setName);
+
+    // But each invocation works correctly
+    settersA.setCount(1);
+    settersB.setCount(2);
+    expect(store.getState().count).toBe(2);
+  });
+});

--- a/src/stores/create-simple-setters.test.ts
+++ b/src/stores/create-simple-setters.test.ts
@@ -82,16 +82,18 @@ describe('createSimpleSetters', () => {
   it('works when action name differs from state key (e.g. setInPoint → inPointMs)', () => {
     interface S {
       playheadMs: number;
-      inPointMs: number | undefined;
+      inPointMs: number;
     }
     interface A {
-      setInPoint: (v: number | undefined) => void;
+      setInPoint: (v: number) => void;
     }
-    const store = create<S & A>((set) => ({
-      playheadMs: 0,
-      inPointMs: undefined,
-      ...createSimpleSetters({ setInPoint: 'inPointMs' }, set),
-    }));
+    const store = create<S & A>((set) => {
+      const initial: S = { playheadMs: 0, inPointMs: 0 };
+      return {
+        ...initial,
+        ...createSimpleSetters({ setInPoint: 'inPointMs' }, set),
+      };
+    });
 
     store.getState().setInPoint(500);
     expect(store.getState().inPointMs).toBe(500);

--- a/src/stores/create-simple-setters.ts
+++ b/src/stores/create-simple-setters.ts
@@ -30,18 +30,22 @@
 
 import type { StoreApi } from 'zustand';
 
-type SetState<S> = StoreApi<S>['setState'];
+/**
+ * 接受 Zustand set 函数（兼容 createPersistedStore 的包装 set 与裸 setState）。
+ * 工厂内部只用 `set({ key: value })` 的简单调用形式，因此只需要 Partial<S> 即可。
+ */
+type SimpleSet<S> = (partial: Partial<S>) => void;
 
 /**
  * 根据 action-name → state-key 映射生成对应的简单 setter。
  *
  * @param map action 名到 state 键的映射
- * @param set Zustand 的 set 函数
+ * @param set Zustand 的 set 函数（createPersistedStore 包装 或 裸 setState 均可）
  * @returns 与 map 同名的 setter 映射，类型按 state 字段推导
  */
 export function createSimpleSetters<S, M extends Record<string, keyof S & string>>(
   map: M,
-  set: SetState<S>,
+  set: SimpleSet<S>,
 ): { [A in keyof M]: (value: S[M[A]]) => void } {
   const setters: Record<string, (value: unknown) => void> = {};
   for (const actionName in map) {
@@ -50,3 +54,6 @@ export function createSimpleSetters<S, M extends Record<string, keyof S & string
   }
   return setters as { [A in keyof M]: (value: S[M[A]]) => void };
 }
+
+// 保留 StoreApi 导出，方便其他场景使用
+export type { StoreApi };

--- a/src/stores/create-simple-setters.ts
+++ b/src/stores/create-simple-setters.ts
@@ -1,0 +1,52 @@
+/**
+ * create-simple-setters.ts
+ *
+ * 为 Zustand store 中无副作用的纯赋值 setter 自动生成实现。
+ * 适用于 `setX: (x) => set({ [stateKey]: x })` 模式。
+ *
+ * 用法（节选自 editor-store.ts）：
+ *   const simpleSetters = createSimpleSetters({
+ *     setVideo: 'video',
+ *     setScript: 'script',
+ *     setIsPlaying: 'isPlaying',
+ *     // 带 clamping / history / 多步操作的 setter 保持手写
+ *   }, set);
+ *
+ *   state: () => ({
+ *     ...initialState,
+ *     ...simpleSetters,
+ *     // 业务 action
+ *   })
+ *
+ * 收益：editor-store 简单 setter 从 19 行手写降到 1 行 factory + 19 行 key 映射。
+ *
+ * 限制：
+ *   - 工厂仅适用纯赋值 setter（setX → set({ key: x })）
+ *   - 带 clamping/validation 的 setter 保持手写
+ *   - 带 history 副作用的 setter 保持手写
+ *   - functional update 的 setter 保持手写
+ *   - 跨字段读写的 setter（如 setInPoint 读 playheadMs）保持手写
+ */
+
+import type { StoreApi } from 'zustand';
+
+type SetState<S> = StoreApi<S>['setState'];
+
+/**
+ * 根据 action-name → state-key 映射生成对应的简单 setter。
+ *
+ * @param map action 名到 state 键的映射
+ * @param set Zustand 的 set 函数
+ * @returns 与 map 同名的 setter 映射，类型按 state 字段推导
+ */
+export function createSimpleSetters<S, M extends Record<string, keyof S & string>>(
+  map: M,
+  set: SetState<S>,
+): { [A in keyof M]: (value: S[M[A]]) => void } {
+  const setters: Record<string, (value: unknown) => void> = {};
+  for (const actionName in map) {
+    const stateKey = map[actionName];
+    setters[actionName] = (value: unknown) => set({ [stateKey]: value } as Partial<S>);
+  }
+  return setters as { [A in keyof M]: (value: S[M[A]]) => void };
+}

--- a/src/stores/editor-store.ts
+++ b/src/stores/editor-store.ts
@@ -9,8 +9,11 @@
  *  - 持久化 key 沿用原 `StoryFab-workspace`（避免用户丢失已缓存的设置）。
  *  - 播放态采用单一 `isPlaying` 命名，原 storyFabStore.isPlaying 与
  *    workspaceStore.previewPlaying 统一收口于此。
+ *  - 简单 setter（无 clamping / history / functional）通过 createSimpleSetters
+ *    工厂自动生成；带副作用的 setter 保持手写（Stage 8 PR-2.2 引入）。
  */
 import { createPersistedStore } from './create-persisted-store';
+import { createSimpleSetters } from './create-simple-setters';
 import { createJSONStorage } from 'zustand/middleware';
 import { createHistory } from './create-history';
 import type { TimelineTrack, TimelineClip, AnimationKeyframe, TrackType } from '@/types';
@@ -174,18 +177,28 @@ export const useEditorStore = createPersistedStore<EditorStore>({
     ...initialEditorState,
     ...initialTimelineState,
 
-    setVideo: (video) => set({ video }),
-    setScript: (script) => set({ script }),
-    setVoice: (voice) => set({ voice }),
-    setActivePanel: (activePanel) => set({ activePanel }),
-    setIsPlaying: (isPlaying) => set({ isPlaying }),
-    setCurrentTime: (currentTime) => set({ currentTime }),
+    // 9 个真正简单的 setter（无 clamping / history / functional）通过工厂生成。
+    // 带副作用的 setter 保持手写（见下方）：setVolume/setZoom/setPlayheadMs/setTimelineDuration
+    // （clamping）、setSelection（functional）、setInPoint/setOutPoint（get 依赖）。
+    ...createSimpleSetters(
+      {
+        setVideo: 'video',
+        setScript: 'script',
+        setVoice: 'voice',
+        setActivePanel: 'activePanel',
+        setIsPlaying: 'isPlaying',
+        setCurrentTime: 'currentTime',
+        setMuted: 'muted',
+        setScrollPosition: 'scrollPosition',
+        setSnapEnabled: 'snapEnabled',
+      },
+      set as (partial: Partial<EditorStore>) => void,
+    ),
+
     setVolume: (volume) => set({ volume: Math.max(VOLUME_MIN, Math.min(VOLUME_MAX, volume)) }),
-    setMuted: (muted) => set({ muted }),
     setSelection: (selection) => set((s) => ({ selection: { ...s.selection, ...selection } })),
     clearSelection: () => set({ selection: { segmentId: undefined, multipleIds: [] } }),
     setZoom: (zoom) => set({ zoom: Math.max(ZOOM_MIN, Math.min(ZOOM_MAX, zoom)) }),
-    setScrollPosition: (scrollPosition) => set({ scrollPosition }),
     reset: () => set({ ...initialEditorState, ...initialTimelineState }),
 
     setPlayheadMs: (ms) => set({ playheadMs: Math.max(0, ms) }),


### PR DESCRIPTION
Stage 8 PR-2.2：editor-store 9 个简单 setter 改用 createSimpleSetters，84→62 行（-22）。其余 15 个 setter 保持手写。