### PR TITLE
refactor(stores): namespace test-only export under __testing (Stage 8 PR-5.3)

### DIFF
--- a/src/stores/editor-store.test.ts
+++ b/src/stores/editor-store.test.ts
@@ -3,10 +3,10 @@
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useEditorStore, __resetTrackHistoryForTest } from './editor-store';
+import { useEditorStore, __testing } from './editor-store';
 
 beforeEach(() => {
-  __resetTrackHistoryForTest();
+  __testing.resetTrackHistory();
   useEditorStore.setState({
     video: null,
     script: null,

--- a/src/stores/editor-store.ts
+++ b/src/stores/editor-store.ts
@@ -50,7 +50,15 @@ export const VOLUME_MAX = 1;
 
 const MAX_HISTORY_SIZE = 19;
 const trackHistory = createHistory<TimelineTrack[]>({ maxSize: MAX_HISTORY_SIZE });
-export const __resetTrackHistoryForTest = () => trackHistory.clear();
+
+/**
+ * 测试专用命名空间（PR-5.3）：
+ * 集中所有测试辅助函数，避免污染模块顶层 export。
+ * 命名约定 `__testing.<name>`：双下划线开头是 lint 警告，ESLint 已配置允许。
+ */
+export const __testing = {
+  resetTrackHistory: () => trackHistory.clear(),
+};
 
 import {
   updateClipInTracks,

--- a/src/stores/timeline-store.test.ts
+++ b/src/stores/timeline-store.test.ts
@@ -2,7 +2,7 @@
  * timelineStore 单元测试
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useEditorStore as useTimelineStore, __resetTrackHistoryForTest } from './editor-store';
+import { useEditorStore as useTimelineStore, __testing } from './editor-store';
 
 // 独立的 createHistory 实例用于单元测试（验证模块行为与 store 一致）
 import { createHistory } from './create-history';
@@ -12,7 +12,7 @@ const _testHistory = createHistory<TimelineTrack[]>({ maxSize: 19 });
 describe('timelineStore', () => {
   beforeEach(() => {
     // Reset 模块闭包内的 history 栈（createHistory 持有独立状态）
-    __resetTrackHistoryForTest();
+    __testing.resetTrackHistory();
     // Reset store state before each test
     useTimelineStore.setState({
       timelineTracks: [],


### PR DESCRIPTION
Stage 8 PR-5.3：__resetTrackHistoryForTest → __testing.resetTrackHistory。