### PR TITLE
refactor(test): add tests for use-timeout + use-local-storage (Stage 9 PR-9)

### DIFF
--- a/src/hooks/use-local-storage.test.ts
+++ b/src/hooks/use-local-storage.test.ts
@@ -1,0 +1,103 @@
+/**
+ * use-local-storage 测试
+ *
+ * Stage 9 PR-9：类型安全 localStorage hook 覆盖
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import useLocalStorage from './use-local-storage';
+
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('returns initial value when localStorage is empty', () => {
+    const { result } = renderHook(() => useLocalStorage('test-key', 'default'));
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('reads existing value from localStorage on mount', () => {
+    window.localStorage.setItem('test-key', JSON.stringify('stored-value'));
+    const { result } = renderHook(() => useLocalStorage('test-key', 'default'));
+    expect(result.current[0]).toBe('stored-value');
+  });
+
+  it('updates value and persists to localStorage on set', () => {
+    const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
+
+    act(() => {
+      result.current[1]('new-value');
+    });
+
+    expect(result.current[0]).toBe('new-value');
+    expect(window.localStorage.getItem('test-key')).toBe(JSON.stringify('new-value'));
+  });
+
+  it('supports function updater', () => {
+    const { result } = renderHook(() => useLocalStorage<number>('counter', 0));
+
+    act(() => {
+      result.current[1]((prev) => prev + 1);
+    });
+    expect(result.current[0]).toBe(1);
+
+    act(() => {
+      result.current[1]((prev) => prev + 1);
+    });
+    expect(result.current[0]).toBe(2);
+  });
+
+  it('handles complex objects', () => {
+    interface User { name: string; age: number }
+    const { result } = renderHook(() => useLocalStorage<User>('user', { name: 'init', age: 0 }));
+
+    act(() => {
+      result.current[1]({ name: 'Alice', age: 30 });
+    });
+
+    expect(result.current[0]).toEqual({ name: 'Alice', age: 30 });
+    expect(JSON.parse(window.localStorage.getItem('user')!)).toEqual({ name: 'Alice', age: 30 });
+  });
+
+  it('handles arrays', () => {
+    const { result } = renderHook(() => useLocalStorage<number[]>('nums', []));
+
+    act(() => {
+      result.current[1]([1, 2, 3]);
+    });
+
+    expect(result.current[0]).toEqual([1, 2, 3]);
+  });
+
+  it('falls back to initial value on JSON parse error', () => {
+    window.localStorage.setItem('bad-key', 'not valid json{');
+    const { result } = renderHook(() => useLocalStorage('bad-key', 'fallback'));
+    expect(result.current[0]).toBe('fallback');
+  });
+
+  it('falls back to initial value when localStorage value is empty string', () => {
+    window.localStorage.setItem('empty-key', '');
+    const { result } = renderHook(() => useLocalStorage('empty-key', 'default'));
+    // Empty string is falsy in JS, so the ternary returns initialValue
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('logs error and keeps state when localStorage.setItem fails', () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('quota exceeded');
+    });
+
+    const { result } = renderHook(() => useLocalStorage('quota-key', 'init'));
+
+    act(() => {
+      result.current[1]('new-value');
+    });
+
+    // State should still update even if storage fails
+    expect(result.current[0]).toBe('new-value');
+    setItemSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/hooks/use-timeout.test.ts
+++ b/src/hooks/use-timeout.test.ts
@@ -1,0 +1,128 @@
+/**
+ * use-timeout 测试
+ *
+ * Stage 9 PR-9：统一 setTimeout 管理 hook 覆盖
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useTimeout } from './use-timeout';
+
+describe('useTimeout', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns set/clear/delay methods', () => {
+    const { result } = renderHook(() => useTimeout());
+    expect(typeof result.current.set).toBe('function');
+    expect(typeof result.current.clear).toBe('function');
+    expect(typeof result.current.delay).toBe('function');
+  });
+
+  it('set() invokes callback after specified delay', () => {
+    const { result } = renderHook(() => useTimeout());
+    const cb = vi.fn();
+
+    act(() => {
+      result.current.set(cb, 1000);
+    });
+
+    expect(cb).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(cb).not.toHaveBeenCalled();
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('set() returns a timeout id', () => {
+    const { result } = renderHook(() => useTimeout());
+    let id: ReturnType<typeof setTimeout> | null = null;
+
+    act(() => {
+      id = result.current.set(() => {}, 1000);
+    });
+
+    expect(id).not.toBeNull();
+  });
+
+  it('clear() cancels pending callback', () => {
+    const { result } = renderHook(() => useTimeout());
+    const cb = vi.fn();
+    let id: ReturnType<typeof setTimeout> | null = null;
+
+    act(() => {
+      id = result.current.set(cb, 1000);
+      result.current.clear(id!);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('delay() returns a Promise that resolves after ms', async () => {
+    const { result } = renderHook(() => useTimeout());
+    let resolved = false;
+
+    act(() => {
+      result.current.delay(1000).then(() => {
+        resolved = true;
+      });
+    });
+
+    expect(resolved).toBe(false);
+    await act(async () => {
+      vi.advanceTimersByTime(1000);
+      await Promise.resolve();
+    });
+    expect(resolved).toBe(true);
+  });
+
+  it('clears all timeouts on unmount', () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    const { result, unmount } = renderHook(() => useTimeout());
+
+    act(() => {
+      result.current.set(cb1, 1000);
+      result.current.set(cb2, 2000);
+    });
+
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(cb1).not.toHaveBeenCalled();
+    expect(cb2).not.toHaveBeenCalled();
+  });
+
+  it('handles multiple timeouts independently', () => {
+    const { result } = renderHook(() => useTimeout());
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+
+    act(() => {
+      result.current.set(cb1, 1000);
+      result.current.set(cb2, 3000);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(cb1).toHaveBeenCalledTimes(1);
+    expect(cb2).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(1500);
+    });
+    expect(cb2).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Stage 9 PR-9：两个独立 utility hook 覆盖（7+9=16 测试）。

use-timeout 覆盖：返回方法 / set 触发 / clear 取消 / delay Promise / 卸载清理 / 多个 timeout 独立

use-local-storage 覆盖：初始 / 读取 / set 持久化 / 函数 updater / 复杂对象 / 数组 / JSON 错误回退 / 空字符串边界 / setItem 失败仍更新 state

全量 1051 → 1067（+16 from PR-9）。
